### PR TITLE
Grab knife path from environment or options hash if possible

### DIFF
--- a/lib/util/knife.js
+++ b/lib/util/knife.js
@@ -26,6 +26,7 @@ var sprintf = require('./sprintf');
 function knife(args, options) {
   return function(callback) {
     var env = misc.copyEnv();
+    var knife_path = '/usr/bin/knife';
     options = options || {};
 
     // Support for these must be implemented in your knife.rb
@@ -37,7 +38,18 @@ function knife(args, options) {
       env['CHEF_USER'] = options.user;
     }
 
-    args = ['/usr/bin/knife'].concat(args);
+    if (env['KNIFE_PATH']) {
+      knife_path = env['KNIFE_PATH'];
+    }
+    else if (options.knife_path) {
+      knife_path = options.knife_path;
+    }
+
+    if (options.knife_config) {
+      args = args.concat(['-c', options.knife_config]);
+    }
+
+    args = [knife_path].concat(args);
 
     misc.spawn(args, {env: env}, function(err, stdout, stderr) {
       var payload;


### PR DESCRIPTION
This addresses https://github.com/racker/dreadnot/issues/18. Default knife path is still /usr/bin/knife, but the default can now be overridden by setting KNIFE_PATH in the environment, or setting the knife_path key in the options hash when calling the knife() function.
