### PR TITLE
Make forcing the build configurable for Jenkins

### DIFF
--- a/lib/util/jenkins.js
+++ b/lib/util/jenkins.js
@@ -55,7 +55,10 @@ Jenkins.prototype.ensureRevisionBuilt = function(builder, branch, revision, call
   var self = this;
   var build = null;
   var polling = false;
+  var forceBuild = self._options.force_build;
   var attempts = 0;
+
+  self.log.infof('Attempting to deploy revision ${rev}...', {rev: revision});
 
   function getLastBuild(callback) {
     self.getRevision(builder, revision, function(err, last_build) {
@@ -75,7 +78,7 @@ Jenkins.prototype.ensureRevisionBuilt = function(builder, branch, revision, call
   function pollJenkins(asyncCallback) {
     var errorMsg;
 
-    if (!polling) {  // Wait a few seconds before the first poll
+    if (!polling && forceBuild) {  // Wait a few seconds before the first poll
       polling = true;
       setTimeout(asyncCallback, self._options.delay);
       return;
@@ -95,7 +98,7 @@ Jenkins.prototype.ensureRevisionBuilt = function(builder, branch, revision, call
       return true;
     }
 
-    if (polling === false) {   // Kick the build, this is the first poll
+    if (polling === false && forceBuild) {   // Kick the build, this is the first poll
       if (!build || build.building === false) {
         self.build(builder, branch, revision, function(err, resp, body) {
           if (err) {
@@ -173,9 +176,10 @@ Jenkins.prototype.build = function(builder, branch, revision, callback) {
     qs : {'REV': revision}
   }
 
-  this.log.infof('Forcing build of revision ${rev}', {
+  this.log.infof('Forcing build of revision ${rev} on ${builder}', {
     rev: revision,
-    options: options
+    options: options,
+    builder: builder
   });
   request.get(options, callback);
 }
@@ -194,10 +198,6 @@ Jenkins.prototype.getRevision = function(builder, revision, callback) {
 
   request.get(url, function(err, response, body) {
     var i, build, buildSha;
-
-    self.log.infof('Got builds from Jenkins, looking for SHA1 ${rev}...', {
-      rev: revision
-    });
 
     if (err) {
       return callback(err);


### PR DESCRIPTION
We have a development pipeline in which Dreadnot is the final step - we don't want it to _create_ Jenkins builds, we want it to deploy _as a result of_ Jenkins builds.  This keeps the original behavior, but allows us to turn the behavior of "no revision was found, force a build" off.
