### PR TITLE
misc.spawn node 0.8 compatibility: stdio data may come after exit.

### DIFF
--- a/lib/util/misc.js
+++ b/lib/util/misc.js
@@ -44,9 +44,9 @@ exports.spawn = function(cmd, spawnOpts, callback) {
       resultString = '',
       errString = '',
       cmdStr,
-      stdout_closed = false,
-      stderr_closed = false,
-      exit_code;
+      stdoutClosed = false,
+      stderrClosed = false,
+      exitCode;
 
   // Copy command so we don't override the parent
   cmd = cmd.slice();
@@ -63,13 +63,13 @@ exports.spawn = function(cmd, spawnOpts, callback) {
     errString += data;
   });
 
-  function closing_event() {
+  function closingEvent() {
     var err;
 
-    if (stdout_closed && stderr_closed && exit_code !== undefined) {
-      log.info('Command finished', {'cmd': cmdStr, 'code': exit_code, 'stdout': resultString, 'stderr': errString});
+    if (stdoutClosed && stderrClosed && exitCode !== undefined) {
+      log.info('Command finished', {'cmd': cmdStr, 'code': exitCode, 'stdout': resultString, 'stderr': errString});
 
-      if (exit_code) {
+      if (exitCode) {
         err = new Error(sprintf('Failed command %s:\nstderr:\n%s\nstdout:\n%s', cmdStr, errString, resultString));
       }
 
@@ -77,16 +77,16 @@ exports.spawn = function(cmd, spawnOpts, callback) {
     }
   }
   proc.stdout.on('close', function() {
-    stdout_closed = true;
-    closing_event();
+    stdoutClosed = true;
+    closingEvent();
   });
   proc.stderr.on('close', function() {
-    stderr_closed = true;
-    closing_event();
+    stderrClosed = true;
+    closingEvent();
   });
   proc.on('exit', function(code) {
-    exit_code = code;
-    closing_event();
+    exitCode = code;
+    closingEvent();
   });
 };
 


### PR DESCRIPTION
[`child_process` API changes between v0.6 and v0.8](https://github.com/joyent/node/wiki/API-changes-between-v0.6-and-v0.8):

> - the `'exit'` event is now emitted right after the child process exits. It no longer waits for all stdio pipes to be closed.
> - the `'close'` event was added that has is emitted after the child has exited and all the stdio pipes are closed.

For node 0.8 compatibility, while keeping compatibility with older version of node, I used the stdio stream `'close'` event to avoid losing any `'data'` events that can occur after the `child_process` `'exit'` event.
