### PR TITLE
Dreadnot: Fix pagerduty util to utilize non-beta URL

### DIFF
--- a/lib/util/pagerduty.js
+++ b/lib/util/pagerduty.js
@@ -66,7 +66,7 @@ PagerDuty.prototype.override = function(schedule, user, startTime, endTime, call
 
   reqOpts = {
     method: 'POST',
-    uri: sprintf('%sapi/beta/schedules/%s/overrides', this.authedURL, scheduleId),
+    uri: sprintf('%sapi/v1/schedules/%s/overrides', this.authedURL, scheduleId),
     headers: {
       'Content-Type': 'application/json'
     },


### PR DESCRIPTION
Per email from Pagerduty, we need to stop using this beta url.
