### PR TITLE
Let user specify a hook to configure webapp in the config file.

### DIFF
--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -154,6 +154,9 @@ exports.run = function(port, dreadnot) {
     app.use(express.cookieParser());
     app.use(express.session({secret: misc.randstr(32), store: sessionStore}));
     //app.use(app.router);
+      if ( dreadnot.config.configure_server ) {
+          dreadnot.config.configure_server(app);
+      }
   });
 
   app.use('/static', express.static(STATIC_DIR));


### PR DESCRIPTION
This allows customization in the web panel without forking, that lets user set up e.g. alternative authentication schemes. I can e.g. configure authentication to just use SSO headers left by frontend Apache, or (sample below) hard-code username for local tests:

``` javascript
    configure_server: function (app) {
        app.enable('trust proxy');
        app.use( function(req, res, next) {
            req.session.authed = true;
            req.session.username = 'japhy';
            next();
        });
    },
```
