### PR TITLE
find oldest successful build instead of just finding the oldest

### DIFF
--- a/lib/util/buildbot.js
+++ b/lib/util/buildbot.js
@@ -87,7 +87,12 @@ BuildBot.prototype.build = function(builder, branch, revision, callback) {
  * Find the oldest build with a given revision.
  */
 BuildBot.prototype._findOldestBuild = function(builds, revision) {
-  var i, j, number, numbers, build, properties, retrybuild;
+  // Logic is to return, in order of preference:
+  // - Oldest Build with status code 0 (success)
+  // - Oldest Build with status code not in [0, 4, 5]
+  // - Newest Build with status code 4 or 5 (retry)
+  var i, j, number, numbers, build, properties, retrybuild,
+      oldestBuild;
 
   // Get numbers of builds from oldest to newest
   numbers = Object.keys(builds).map(function(numstr) {
@@ -121,15 +126,24 @@ BuildBot.prototype._findOldestBuild = function(builds, revision) {
             continue;
           }
 
-          return build;
+          if (oldestBuild === undefined) {
+            oldestBuild = build;
+          }
+
+          if (build.results === 0) {
+            return build;
+          }
         }
       }
     }
   }
 
+  if (oldestBuild !== undefined) {
+    return oldestBuild;
+  }
+
   return retrybuild;
 };
-
 
 /**
  * Get a build for a specified revision.


### PR DESCRIPTION
If a successful build exists for a given revision, return the oldest successful build instead of just returning the oldest build.
