### PR TITLE
Add 'error' handler on the request object.

### DIFF
--- a/lib/web/middleware/logger.js
+++ b/lib/web/middleware/logger.js
@@ -34,7 +34,7 @@ module.exports = function() {
     var end = res.end;
 
     res.on('error', function(err) {
-      log.error('Failed to send a response: ' + err.toString());
+      log.error('Error has been emitted on the request object: ' + err.toString());
     });
 
     res.end = function(chunk, encoding) {


### PR DESCRIPTION
Currently there is no handler for `error` event in the logger middleware which means dreadnot will crash because of uncaught exception if for some reason we can't send response to the client (`res.end` emits an error).

Here is an example error which happened to me multiple times already:

``` events.js:71
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: socket hang up
    at createHangUpError (http.js:1360:15)
    at ServerResponse.OutgoingMessage._writeRaw (http.js:507:26)
    at ServerResponse.OutgoingMessage._send (http.js:476:15)
    at ServerResponse.OutgoingMessage.write (http.js:740:18)
    at ServerResponse.OutgoingMessage.end (http.js:882:16)
    at ServerResponse.module.exports.res.end (/opt/dn-bundle-f3231027f10bfb27a1098e2752a9fb485e19dcfd/lib/web/middleware/logger.js:38:11)
    at res.end (/opt/dn-bundle-f3231027f10bfb27a1098e2752a9fb485e19dcfd/node_modules/connect/lib/middleware/session.js:282:15)
    at /opt/dn-bundle-f3231027f10bfb27a1098e2752a9fb485e19dcfd/node_modules/connect/lib/middleware/session/memory.js:75:11
```
