### PR TITLE
Setting for specifying a "github_base_url".

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -160,7 +160,8 @@ Stack.prototype.getRepoUrl = function() {
 
 
 Stack.prototype.getGitHubBaseUrl = function() {
-  return sprintf('https://github.com/%s/%s', this.config.github.organization, this.name);
+  return this.stackConfig.github_base_url ||
+    sprintf('https://github.com/%s/%s', this.config.github.organization, this.name);
 };
 
 


### PR DESCRIPTION
This is just the github version of stackConfig.git_url.

It's nice to be able to use a custom URL since we already have the ability to specify a custom git_url.
