### PR TITLE
Bail with usage message if config does not exist.

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -36,8 +36,14 @@ exports.run = function() {
   argv = optimist.argv;
 
   logmagic.route('__root__', logmagic.DEBUG, argv['log-sink']);
-
-  config = require(path.resolve(argv.c)).config;
+  
+  try {
+    config = require(path.resolve(argv.c)).config;
+  } catch (e) {
+    optimist.showHelp();
+    log.error(e);
+    process.exit(1);
+  }
   d = new Dreadnot(config, argv.s);
 
   d.init(function(err) {


### PR DESCRIPTION
Catch and handle the exception which occurs if -c
does not exist.
