### PR TITLE
Guard against 'null' actions when determining lastBuiltRevision.

### DIFF
--- a/lib/util/jenkins.js
+++ b/lib/util/jenkins.js
@@ -233,7 +233,7 @@ Jenkins.prototype._getBuildSHA = function (build) {
 
   for (i=0; i < build.actions.length; i++) {
     action = actions[i];
-    if (action.hasOwnProperty('lastBuiltRevision')) {
+    if (action && action.hasOwnProperty('lastBuiltRevision')) {
       return action.lastBuiltRevision.SHA1;
     }
   }


### PR DESCRIPTION
We recently upgraded our Jenkins and started to get `null` actions returned in the tree like

``` javascript
{
  actions: [
    { },
    { },
    null,
    {
      lastBuiltRevision: {
      SHA1: "0faf4733647f9d0a1c2ebeff72b8b86d72a39e92"
    },
    { },
    { },
    { }
  ],
  building: false,
  fullDisplayName: "Chef #12",
  number: 12,
  result: "SUCCESS",
  timestamp: 1373657574000,
  url: "http://$JENKINS_URL/job/Chef/12/"
}
```

The 'null' action causes the Jenkins code that determines the lastBuiltRevision to blow up.  This patch adds a guard.
