### PR TITLE
Add support for toggling notifications for nagios by servicegroups

### DIFF
--- a/lib/util/nagios.js
+++ b/lib/util/nagios.js
@@ -86,7 +86,7 @@ Nagios.prototype.disableServiceGroupNotifications = function(group, callback) {
       data = {
         cmd_typ: 110,
         cmd_mod: 2,
-        hostgroup: group,
+        servicegroup: group,
         ahas: 'on',
         btnSubmit: 'Commit'
       },
@@ -115,7 +115,7 @@ Nagios.prototype.enableServiceGroupNotifications = function(group, callback) {
       data = {
         cmd_typ: 109,
         cmd_mod: 2,
-        hostgroup: group,
+        servicegroup: group,
         ahas: 'on',
         btnSubmit: 'Commit'
       },


### PR DESCRIPTION
Support toggling alerts by nagios servicegroups as well as hostgroups.
Also updated log messages to indicate whether alerts are being disabled
for a servicegroup or hostgroup.

Lastly updated comments to reflect that host notifications are NOT
disabled along with service notifications.
