### PR TITLE
Add parallelLimit to knife.queryAndRun

### DIFF
--- a/lib/util/knife.js
+++ b/lib/util/knife.js
@@ -129,11 +129,12 @@ function queryAndRun(baton, args, query, cmd, msg, options, callback) {
     callback = options;
     options = null;
   }
+  var parallelLimitFunc, stopOnFailure, getHostParams;
 
-  var parallelLimitFunc = options && options.parallelLimitFunc ? options.parallelLimitFunc : null;
-  var stopOnFailure = parallelLimitFunc !== null;
+  parallelLimitFunc = options && options.parallelLimitFunc || null;
+  stopOnFailure = !!parallelLimitFunc;
 
-  var getHostParams = options && options.getHostParams ? options.getHostParams : function(hostObj) {
+  getHostParams = options && options.getHostParams ? options.getHostParams : function(hostObj) {
     return {
       ip: hostObj.automatic.ipaddress
     };
@@ -197,8 +198,12 @@ function queryAndRun(baton, args, query, cmd, msg, options, callback) {
       length: results.rows.length
     });
 
-    var eachFunc = async.map;
-    var eachFuncCallback = function(_, errors) {
+    var eachFunc, eachFuncCallback;
+    eachFunc = async.map;
+    eachFuncCallback = function(err, errors) {
+      // note, err is unused here. async will short circuit when err is passed,
+      // and legacy functionality is to run cmd against every host, regardless
+      // of errors.
       var failed = errors.filter(function(err) {
         return err;
       }).length;


### PR DESCRIPTION
**Update**

See my comment below for more details.

---

Add ability to limit the number of concurrent tasks run against the servers knife returns. Also support functions as the value for parallelLimitFunc so users can limit the number of tasks run in parallel based on the number of servers found.

The primary motivation for this is to make it possible to do a rolling run of chef on servers.

This is fully backwards compatible, parallelLimitFunc is optional.

Note: if the task being run by queryAndRun fails, then that task will NOT be run on the remaining servers. If the parallelLimitFunc is more than one, however, and the jobs running against the other servers will finish their runs.

One thing to be aware of: there is no guarantee that jobs will be run on servers in the same order. If one run fails, the next run will most likely NOT start on the server that failed last time.
