### PR TITLE
dreadnot web should watch for changes to htpasswd

### DIFF
--- a/lib/web/auth.js
+++ b/lib/web/auth.js
@@ -137,11 +137,12 @@ function md5crypt(password, salt, magic) {
   return magic + salt + '$' + rearranged;
 }
 
-function getUsers(err, data) {
-  var users = {},
+function getUsers(filePath) {
+  var contents = fs.readFileSync(filePath, 'utf-8'),
+      users = {},
       lines, both, i;
 
-  lines = data.split('\n').map(function(line) {
+  lines = contents.split('\n').map(function(line) {
     return line.trim();
   });
 
@@ -154,19 +155,18 @@ function getUsers(err, data) {
   return users;
 }
 
-function onSIGHUP(){
-  var users = fs.readFile(this.filePath, 'utf-8', getUsers);
-  this.myAuthDB.updateUsers(users);
+function loadDBFromFile(filePath) {
+  fs.watch(filePath, {
+    'persistent': false
+  }, process.kill.bind(null, process.pid, 'SIGHUP'));
+
+  var db = new AuthDB(getUsers(filePath));
+
+  process.on('SIGHUP', function() {
+    db.updateUsers(getUsers(filePath));
+  });
+
+  return db;
 }
 
-function loadDBFromFile(filePath) {
-  fs.watch(filePath, { 'persistent': false }, process.kill.bind(this,
-           process.pid, 'SIGHUP'));
-  var users = fs.readFile(filePath, 'utf-8', getUsers),
-      myAuthDB = new AuthDB(users);
-  this.myAuthDB = myAuthDB;
-  this.filePath = filePath;
-  process.on('SIGHUP', onSIGHUP.bind(this));
-  return myAuthDB;
-}
 exports.loadDBFromFile = loadDBFromFile;


### PR DESCRIPTION
This introduces a few changes:
- getUsers now reads from htpasswd asynchronously
- loadDBFromFile calls an fs.watch, which always sends SIGHUP on change
- loadDBFromFile uses bind to pass the file name along to onSIGHUP
- onSIGHUP handles the reloading of the files
