### PR TITLE
Enable mod_proxy ProxyPass support.

### DIFF
--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -144,7 +144,14 @@ exports.registerAPI = function(dreadnot, authdb) {
 exports.run = function(port, dreadnot) {
   var app = express.createServer(),
       authdb = auth.loadDBFromFile(dreadnot.config.htpasswd_file),
-      sessionStore = new connect.session.MemoryStore({maxAge: 7 * 24 * 60 * 60 * 1000});
+      sessionStore = new connect.session.MemoryStore({maxAge: 7 * 24 * 60 * 60 * 1000}),
+      urlRe = new RegExp('.*?//.*?/(.*)');
+  
+  if (urlRe.test(dreadnot.config.default_url)) {
+    dreadnot.urlPrepend = '/' + urlRe.exec(dreadnot.config.default_url)[1]; // '/' + foo/bar/baz
+  } else {
+    dreadnot.urlPrepend = '';
+  }
 
   app.configure(function() {
     // Middleware
@@ -159,9 +166,9 @@ exports.run = function(port, dreadnot) {
       }
   });
 
-  app.use('/static', express.static(STATIC_DIR));
-  app.use('/api', exports.registerAPI(dreadnot, authdb));
-  app.use('/', exports.registerWeb(dreadnot, authdb));
+  app.use(dreadnot.urlPrepend + '/static', express.static(STATIC_DIR));
+  app.use(dreadnot.urlPrepend + '/api', exports.registerAPI(dreadnot, authdb));
+  app.use(dreadnot.urlPrepend + '/', exports.registerWeb(dreadnot, authdb));
 
   // Catch 404s
   app.get('*', function(req, res, next) {

--- a/lib/web/handlers/web.js
+++ b/lib/web/handlers/web.js
@@ -33,6 +33,7 @@ exports.getWebHandlers = function(dreadnot, authdb) {
       user: req.remoteUser,
       title: dreadnot.config.name,
       env: dreadnot.config.env,
+      urlPrepend: dreadnot.urlPrepend,
       url: req.originalUrl,
       emsg: res.emsg,
       wmsg: dreadnot.warning,
@@ -58,6 +59,7 @@ exports.getWebHandlers = function(dreadnot, authdb) {
       if (err) {
         handleError(req, res, err);
       } else {
+        data.urlPrepend = dreadnot.urlPrepend;
         render(req, res, template, data);
       }
     };
@@ -66,7 +68,7 @@ exports.getWebHandlers = function(dreadnot, authdb) {
   // Render the Login page
   function getLogin(req, res) {
     var next = req.param('next');
-    render(req, res, 'login.jade', {next: next});
+    render(req, res, 'login.jade', {next: next, urlPrepend: dreadnot.urlPrepend});
   }
 
   // Handle Login attempts, redirect on success, render Login with error on failure
@@ -82,7 +84,7 @@ exports.getWebHandlers = function(dreadnot, authdb) {
         res.redirect(next);
       } else {
         res.emsg = 'Invalid Username or Password';
-        render(req, res, 'login.jade', {next: next});
+        render(req, res, 'login.jade', {next: next, urlPrepend: dreadnot.urlPrepend});
       }
     });
   }
@@ -90,7 +92,7 @@ exports.getWebHandlers = function(dreadnot, authdb) {
   // Handle logout attempts
   function logout(req, res) {
     req.session.destroy();
-    res.redirect('/');
+    res.redirect(dreadnot.urlPrepend + '/');
   }
 
   // Render the main overview page
@@ -194,14 +196,14 @@ exports.getWebHandlers = function(dreadnot, authdb) {
         res.respond(err);
         return;
       } else {
-        res.redirect(sprintf('/stacks/%s/regions/%s/deployments/%s', stackName, regionName, number));
+        res.redirect(sprintf('%s/stacks/%s/regions/%s/deployments/%s', dreadnot.urlPrepend, stackName, regionName, number));
       }
     });
   }
 
   // Render the warning editing view
   function getWarning(req, res) {
-    render(req, res, 'warning.jade', {});
+    render(req, res, 'warning.jade', { urlPrepend: dreadnot.urlPrepend });
   }
 
   // Store the warning message

--- a/lib/web/views/deployment.jade
+++ b/lib/web/views/deployment.jade
@@ -4,7 +4,7 @@ block title
   h1 Deployment \##{data.deployment.name} of #{data.stack.name}:#{data.region.name}
 
 block upnav
-  a(href='/stacks/#{data.stack.name}/regions/#{data.region.name}') &larr; back to #{data.region.name}
+  a(href='#{data.urlPrepend}/stacks/#{data.stack.name}/regions/#{data.region.name}') &larr; back to #{data.region.name}
 
 block scripts
   - var log = {stack: data.stack.name, region: data.region.name, deployment: data.deployment.name};

--- a/lib/web/views/deployments.jade
+++ b/lib/web/views/deployments.jade
@@ -9,7 +9,7 @@ block title
   h1 #{data.stack.name}:#{data.region.name}
 
 block upnav
-  a(href='/') &larr; back to #{env}
+  a(href='#{data.urlPrepend}/') &larr; back to #{env}
 
 block content
   - if (user.authorized)
@@ -24,7 +24,7 @@ block content
           a(href='#')#fearless.btn.primary Deploy Anyway
           a(href='#')#fearful.btn.secondary Cancel
 
-    form(method='post', action='/stacks/#{data.stack.name}/regions/#{data.region.name}')#deploy-form
+    form(method='post', action='#{data.urlPrepend}/stacks/#{data.stack.name}/regions/#{data.region.name}')#deploy-form
       p
         input(type='text', name='to_revision', size='40', value='#{data.stack.latest_revision}')#to_revision.full_hash
       p !{helpers.buildDiffSegment(data.stack.github_href, data.region.deployed_revision, data.stack.latest_revision)}
@@ -47,7 +47,7 @@ block content
       - each deployment in data.deployments
         tr
           td
-            a(href='/stacks/#{data.stack.name}/regions/#{data.region.name}/deployments/#{deployment.name}') #{deployment.name}
+            a(href='#{data.urlPrepend}/stacks/#{data.stack.name}/regions/#{data.region.name}/deployments/#{deployment.name}') #{deployment.name}
           td #{helpers.prettyTimeSince(deployment.time)}
           td #{deployment.user}
           td !{helpers.buildDiffSegment(data.stack.github_href, deployment.from_revision, deployment.to_revision)}

--- a/lib/web/views/dn2.jade
+++ b/lib/web/views/dn2.jade
@@ -3,14 +3,14 @@ html(lang='en')
   head
     title Dreadnot
 
-    link(rel='stylesheet', href='/static/css/bootstrap.min.css', type='text/css')
-    link(rel='stylesheet', href='/static/css/dreadnot.css', type='text/css')
-    link(rel='icon', type="image/png", href='/static/dreadnot.png')
+    link(rel='stylesheet', href='#{data.urlPrepend}/static/css/bootstrap.min.css', type='text/css')
+    link(rel='stylesheet', href='#{data.urlPrepend}/static/css/dreadnot.css', type='text/css')
+    link(rel='icon', type="image/png", href='#{data.urlPrepend}/static/dreadnot.png')
 
   body
-    script(src='/static/js/jquery-1.7.0.min.js')
-    script(src='/static/js/underscore-min.js')
-    script(src='/static/js/backbone-min.js')
-    script(src='/socket.io/socket.io.js')
-    script(src='/static/js/bootstrap-modal.js')
-    script(src='/static/js/dn2.js')
+    script(src='#{data.urlPrepend}/static/js/jquery-1.7.0.min.js')
+    script(src='#{data.urlPrepend}/static/js/underscore-min.js')
+    script(src='#{data.urlPrepend}/static/js/backbone-min.js')
+    script(src='#{data.urlPrepend}/socket.io/socket.io.js')
+    script(src='#{data.urlPrepend}/static/js/bootstrap-modal.js')
+    script(src='#{data.urlPrepend}/static/js/dn2.js')

--- a/lib/web/views/layout-deploy.jade
+++ b/lib/web/views/layout-deploy.jade
@@ -2,6 +2,6 @@ extends layout
 
 block topnav
   li.active
-    a(href='/') Deploy
+    a(href='#{data.urlPrepend}/') Deploy
   li
-    a(href='/warning') Warning Message
+    a(href='#{data.urlPrepend}/warning') Warning Message

--- a/lib/web/views/layout.jade
+++ b/lib/web/views/layout.jade
@@ -3,34 +3,34 @@ html(lang='en')
   head
     title #{title}
 
-    link(rel='stylesheet', href='/static/css/bootstrap.min.css', type='text/css')
-    link(rel='stylesheet', href='/static/css/dreadnot.css', type='text/css')
-    link(rel='icon', type="image/png", href='/static/dreadnot.png')
+    link(rel='stylesheet', href='#{data.urlPrepend}/static/css/bootstrap.min.css', type='text/css')
+    link(rel='stylesheet', href='#{data.urlPrepend}/static/css/dreadnot.css', type='text/css')
+    link(rel='icon', type="image/png", href='#{data.urlPrepend}/static/dreadnot.png')
 
-    script(src='/static/js/jquery-1.7.0.min.js')
-    script(src='/static/js/bootstrap-modal.js')
-    script(src='/static/js/dreadnot.js')
+    script(src='#{data.urlPrepend}/static/js/jquery-1.7.0.min.js')
+    script(src='#{data.urlPrepend}/static/js/bootstrap-modal.js')
+    script(src='#{data.urlPrepend}/static/js/dreadnot.js')
     block scripts
 
   body
     div.topbar
       div.fill
         div.container
-          a(href='/').brand #{title}
+          a(href='#{data.urlPrepend}/').brand #{title}
           ul
             block topnav
               li
-                a(href='/') Deploy
+                a(href='#{data.urlPrepend}/') Deploy
               li
-                a(href='/warning') Warning Message
+                a(href='#{data.urlPrepend}/warning') Warning Message
           p.pull-right
             - if (!user)
               | Not signed in
             - else if (user.authorized)
               | Logged in as #{user.name},
-              a(href='/logout') log out
+              a(href='#{data.urlPrepend}/logout') log out
             - else
-              a(href='/login?next=#{url}') Log in
+              a(href='#{data.urlPrepend}/login?next=#{url}') Log in
     
     div.container
       div.content

--- a/lib/web/views/login.jade
+++ b/lib/web/views/login.jade
@@ -4,7 +4,7 @@ block title
   h1 Log In
 
 block content
-  form(method='post', action='/login')
+  form(method='post', action='#{data.urlPrepend}/login')
     - if (data.next)
       input(type='hidden', name='next', value='#{data.next}')
     div.clearfix

--- a/lib/web/views/stacks.jade
+++ b/lib/web/views/stacks.jade
@@ -18,7 +18,7 @@ block content
         - each region in stack.regions
           tr
             td
-              a(href='/stacks/#{stack.name}/regions/#{region.name}') #{region.name}
+              a(href='#{data.urlPrepend}/stacks/#{stack.name}/regions/#{region.name}') #{region.name}
             td !{helpers.buildSingleDiffSegment(stack.github_href, region.deployed_revision, stack.latest_revision)}
             td
               - if (!region.latest_deployment)
@@ -30,11 +30,11 @@ block content
                 span.label No deployments yet
               - else
                 - if (!region.latest_deployment.finished)
-                  a(href='/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label
+                  a(href='#{data.urlPrepend}/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label
                     | Deployment \##{region.latest_deployment.name} in progress
                 - else if (region.latest_deployment.success)
-                  a(href='/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label.success
+                  a(href='#{data.urlPrepend}/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label.success
                     | Deployment \##{region.latest_deployment.name} succeeded
                 - else
-                  a(href='/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label.important
+                  a(href='#{data.urlPrepend}/stacks/#{stack.name}/regions/#{region.name}/deployments/#{region.latest_deployment.name}').label.important
                     | Deployment \##{region.latest_deployment.name} failed

--- a/lib/web/views/warning.jade
+++ b/lib/web/views/warning.jade
@@ -2,9 +2,9 @@ extends layout
 
 block topnav
   li
-    a(href='/') Deploy
+    a(href='#{data.urlPrepend}/') Deploy
   li.active
-    a(href='/warning') Warning Message
+    a(href='#{data.urlPrepend}/warning') Warning Message
 
 block title
   h1 Dreadnot Warning
@@ -12,7 +12,7 @@ block title
 block warning
 
 block content
-  form(method='post', action='/warning').form-stacked
+  form(method='post', action='#{data.urlPrepend}/warning').form-stacked
     fieldset
       div.clearfix
         label(for='warning_text') Warning Text

--- a/static/js/dreadnot.js
+++ b/static/js/dreadnot.js
@@ -2,8 +2,17 @@
 
 
 function streamLogs(log) {
+  console.log(window.location);
+  console.log(window.location.pathname);
   var logPath = ['stacks', log.stack, 'regions', log.region, 'deployments', log.deployment, 'log'].join('/');
-      dest = $('pre.deployment_log');
+      dest = $('pre.deployment_log'),
+      prependRe = new RegExp('/(.*?)/stacks/.*'),
+      urlPrepend = '';
+  
+  if (prependRe.test(window.location.pathname)) {
+    urlPrepend = prependRe.exec(window.location.pathname)[1];
+    logPath = urlPrepend + '/' + logPath;
+  }
 
   function pushEntry(entry) {
     var scroll = Math.abs(dest[0].scrollTop - (dest[0].scrollHeight - dest[0].offsetHeight)) < 10,


### PR DESCRIPTION
Most changes involve adjusting absolute URLs to include a prepend. The prepend is currently defined as whatever is after the host:port in config.default_url.

This allows DN to run localhost:someport but fixes urls so that they point to somewhere else (going through the proxy), as what may happen if you're using Apache to proxy from an apache instance running other websites to a dreadnot or multiple dreadnots as the case may be.

I didn't bother with the dn2 2.0 API stuff since it doesn't look to be going anywhere quickly.