### PR TITLE
feat(cloud monitoring): add support for cloud monitoring suppressions

### DIFF
--- a/lib/util/cloudmonitoring.js
+++ b/lib/util/cloudmonitoring.js
@@ -1,0 +1,253 @@
+/*
+ *  Copyright 2014 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Please define cloudmonitoring : { username: 'user', apiKey: 'key' }
+ *  in your dreadnot settings file before using.
+ *
+ */
+
+var logmagic = require('logmagic');
+var request = require('request');
+var async = require('async');
+
+var KeystoneClient = require('keystone-client').KeystoneClient;
+
+var DEFAULT_AUTH_URI = 'https://identity.api.rackspacecloud.com/v2.0';
+var MONITORING_API_URI = 'https://monitoring.api.rackspacecloud.com:443/v1.0';
+var DEFAULT_SUPPRESSION_DURATION = 30 * 60 * 1000; //30 mins
+
+
+/**
+ * Cloud Monitoring Client.
+ * @constructor
+ * @param {Object} options The options.
+ */
+function CloudMonitoring(options, log) {
+  this._options = options;
+  this.log = log || logmagic.local('cloudmonitoring');
+  this.defaultSuppressionDuration = options.defaultSuppressionDuration || DEFAULT_SUPPRESSION_DURATION;
+
+  this.keystoneClient = new KeystoneClient(options.authUri || DEFAULT_AUTH_URI, {
+      username: options.username,
+      apiKey: options.apiKey
+    }
+  );
+}
+
+
+/**
+ * Gets a list of all entities on an account.
+ * @param {Function} callback The callback.
+ */
+CloudMonitoring.prototype.getEntities = function(callback) {
+  var auth,
+      entities,
+      self = this;
+
+  async.series([
+    function getToken(callback) {
+      self.keystoneClient.getTenantIdAndToken(null, function(err, _auth) {
+        if (err) {
+          self.log.error('could not authenticate to Keystone: ' + err);
+        }
+
+        auth = _auth;
+        callback(err);
+      });
+    },
+    function listEntitiesForAccount(callback) {
+      //TODO: paginate.
+      request({
+        uri: [MONITORING_API_URI, auth.tenantId, 'entities?limit=1000'].join('/'),
+        method: 'GET',
+        headers: {
+          'X-Auth-Token': auth.token
+        }
+      },
+      function(_err, response, body) {
+        var err = _err;
+        if (err || response.statusCode !== 200) {
+          self.log.error('failed to list cloud monitoring entities', {err: err, body: body});
+          if (!err) {
+            err = new Error('non-200 status code received');
+          }
+        } else {
+          try {
+            entities = JSON.parse(body).values;
+          } catch (_err) {
+            self.log.error('cloud monitoring returned invalid data', {err: _err, body: body});
+            err = new Error('malformed api response received');
+          }
+        }
+        callback(err);
+      });
+    }],
+    function asyncHandler(err) {
+      callback(err, entities);
+    });
+};
+
+
+/**
+ * Returns the list of entitiy IDs whose label was matched by pattern.
+ * If your entity labels are set to your servers' hostnames, this is very useful
+ * to get all the entity ids of a region before creating a suppression.
+ * @param {RegExp} pattern The regexp to match entity labels against.
+ * @param {Function} callback The callback.
+ */
+CloudMonitoring.prototype.getEntityIdsByRegex = function(pattern, callback) {
+  this.getEntities(function(err, entities) {
+    var matchedEntityIds = [];
+
+    if (err) {
+      callback(err, null);
+    } else {
+      entities.forEach(function(entity) {
+        if (entity.hasOwnProperty('label') && pattern.test(entity.label)) {
+          matchedEntityIds.push(entity.id);
+        }
+      });
+
+      callback(null, matchedEntityIds);
+    }
+  });
+};
+
+
+/*
+ * Creates a suppression for a group of entities.
+ * @param {Array} entities The list of entity ids to suppress.
+ * @param {Integer} startTime A unix timestamp in ms when to start the suppression (0 or null means right away).
+ * @param {Integer} endTime A unix timestamp in ms when to end the suppression (set to null to use this.defaultSuppressionDuration)
+ * @param {Function} callback A callback.
+ */
+CloudMonitoring.prototype.createEntitiesSuppression = function(entities, startTime, endTime, callback) {
+  var auth,
+      self = this,
+      suppression = {
+        entities: entities,
+        start_time: startTime || 0,
+        end_time: endTime || (Date.now() + this.defaultSuppressionDuration)
+      },
+      suppressionId;
+
+  if (!entities || !entities instanceof Array || entities.length === 0) {
+    this.log.warn('no entities to set a suppression on, skipping');
+    callback(new Error('requested a suppression on zero entities'));
+    return;
+  }
+
+  async.series([
+    function getToken(callback) {
+      self.keystoneClient.getTenantIdAndToken(null, function(err, _auth) {
+        if (err) {
+          self.log.error('could not authenticate to Keystone: ' + err);
+        }
+
+        auth = _auth;
+        callback(err);
+      });
+    },
+    function createSuppression(callback) {
+      request({
+        uri: [MONITORING_API_URI, auth.tenantId, 'suppressions'].join('/'),
+        method: 'POST',
+        headers: {
+          'X-Auth-Token': auth.token
+        },
+        body: JSON.stringify(suppression)
+      },
+      function(_err, response, body) {
+        var err = _err,
+            suppressionUri;
+
+        if (err || response.statusCode !== 201) {
+          self.log.error('failed to create suppression', {err: err, body: body});
+          if (!err) {
+            err = new Error('non-201 status code received');
+          }
+        } else {
+          // The api returns an uri pointing to the suppression in the form of
+          // https://monitoring.api.rackspacecloud.com/v1.0/12345/suppressions/splOUfE2xI
+          // where splOUfE2xI is the suppression ID we want to remember.
+          if (response.headers.hasOwnProperty('location')) {
+            suppressionUri = response.headers['location'].split('/');
+            suppressionId = suppressionUri[suppressionUri.length-1];
+          }
+
+          if (!suppressionId) {
+            self.log.error('cloud monitoring returned invalid data', {headers: response.headers});
+            err = new Error('malformed api response received');
+          } else {
+            self.log.info('created suppression id ' + suppressionId);
+          }
+        }
+        callback(err);
+      });
+    }],
+    function asyncHandler(err) {
+      callback(err, suppressionId);
+    });
+};
+
+
+/*
+ * Deletes the specified suppresion.
+ * @param {String} suppressionId The id of the suppression to delete.
+ * @param {Function} callback A callback.
+ */
+CloudMonitoring.prototype.deleteSuppression = function(suppressionId, callback) {
+  var auth,
+      self = this;
+
+  async.series([
+    function getToken(callback) {
+      self.keystoneClient.getTenantIdAndToken(null, function(err, _auth) {
+        if (err) {
+          self.log.error('could not authenticate to Keystone: ' + err);
+        }
+
+        auth = _auth;
+        callback(err);
+      });
+    },
+    function deleteSuppression(callback) {
+      request({
+        uri: [MONITORING_API_URI, auth.tenantId, 'suppressions', suppressionId].join('/'),
+        method: 'DELETE',
+        headers: {
+          'X-Auth-Token': auth.token
+        }
+      },
+      function(_err, response, body) {
+        var err = _err;
+
+        if (err || response.statusCode !== 204) {
+          self.log.error('failed to delete suppression', {err: err, body: body});
+          if (!err) {
+            err = new Error('non-204 status code received');
+          }
+        }
+        callback(err);
+      });
+    }],
+    function asyncHandler(err) {
+      callback(err, suppressionId);
+    });
+};
+
+
+/** CloudMonitoring Class */
+exports.CloudMonitoring = CloudMonitoring;

--- a/node_modules/keystone-client/.lvimrc
+++ b/node_modules/keystone-client/.lvimrc
@@ -1,0 +1,3 @@
+set tabstop=2
+set shiftwidth=2
+set expandtab

--- a/node_modules/keystone-client/.npmignore
+++ b/node_modules/keystone-client/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+*.log

--- a/node_modules/keystone-client/.travis.yml
+++ b/node_modules/keystone-client/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+node_js:
+  - 0.6
+
+before_script: npm run-script lint
+script: npm run-script lint
+
+notifications:
+  email:
+    - tomaz+travisci@tomaz.me

--- a/node_modules/keystone-client/LICENSE
+++ b/node_modules/keystone-client/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/node_modules/keystone-client/README.md
+++ b/node_modules/keystone-client/README.md
@@ -1,0 +1,11 @@
+# Node.js Keystone Client
+
+A Node.js client for the [OpenStack Keystone Identity service](http://keystone.openstack.org/).
+
+# Build status
+
+[![Build Status](https://secure.travis-ci.org/racker/node-keystone-client.png)](http://travis-ci.org/racker/node-keystone-client)
+
+# License
+
+This library is distributed under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/node_modules/keystone-client/dev-bin/mock-auth-api-server
+++ b/node_modules/keystone-client/dev-bin/mock-auth-api-server
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+/**
+ * Entry point to Mock Auth API  HTTP server.
+ */
+
+var server = require('../tests/mock-auth-server');
+
+function main() {
+  server.run();
+}
+
+main();

--- a/node_modules/keystone-client/jshint.json
+++ b/node_modules/keystone-client/jshint.json
@@ -1,0 +1,18 @@
+{
+    "maxerr"        : 100,
+    "node"          : true,
+    "curly"         : true,
+    "eqeqeq"        : true,
+    "latedef"       : false,
+    "undef"         : true,
+    "newcap"        : true,
+    "nonew"         : true,
+    "onevar"        : false,
+    "trailing"      : true,
+    "white"         : false,
+    "sub"           : true,
+    "evil"          : true,
+    "es5"           : true,
+    "onecase"       : true,
+    "strict"        : false
+}

--- a/node_modules/keystone-client/lib/client.js
+++ b/node_modules/keystone-client/lib/client.js
@@ -1,0 +1,382 @@
+/**
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var querystring = require('querystring');
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+var async = require('async');
+var sprintf = require('sprintf').sprintf;
+
+var request = require('rackspace-shared-utils/lib/request');
+var errors = require('rackspace-shared-utils/lib/errors');
+
+var KEYSTONE_SUCCESS_STATUS_CODES = [200, 203];
+
+/*
+ * How long to cache the admin token for before obtaining a new one.
+ * @type {Number}
+ */
+var DEFAULT_CACHE_TOKEN_FOR = 60;
+
+/**
+ * OpenStack Keystone Identity API client.
+ *
+ * @param {String} url Base keystone server url including the version.
+ * @param {Object} options Authentication options (username, apiKey, password,
+ * cacheTokenFor).
+ * @constructor
+ */
+function KeystoneClient(url, options) {
+  options = options || {};
+
+  if (options.username) {
+    if (!options.password && !options.apiKey) {
+      throw new Error('If username is provided you also need to provide password or apiKey');
+    }
+  }
+
+  this._url = url;
+  this._username = options.username;
+  this._apiKey = options.apiKey;
+  this._password = options.password;
+  this._extraArgs = options.extraArgs || {};
+  this._cacheTokenFor = options.cacheTokenFor || DEFAULT_CACHE_TOKEN_FOR;
+
+  this._token = null;
+  this._tokenExpires = null;
+  this._refreshTokenCompletions = [];
+  this._tokenUpdated = 0;
+  this._tenantId = null;
+  this._serviceCatalog = [];
+}
+
+util.inherits(KeystoneClient, EventEmitter);
+
+/**
+ * @return {Object} default http request options.
+ */
+KeystoneClient.prototype._defaultOptions = function() {
+  var options = {
+    'parse_json': true,
+    'expected_status_codes': KEYSTONE_SUCCESS_STATUS_CODES,
+    'headers': {'Accept': 'application/json', 'Content-Type': 'application/json'},
+    'timeout': 5000,
+    'return_response': true
+  };
+  return options;
+};
+
+/**
+ * Ensure we have a relatively fresh auth api token.
+ *
+ * @param {Boolean} force Forcefully update the token, ignoring a cache
+ * interval.
+ * @param {Function} callback Completion callback.
+ */
+KeystoneClient.prototype._freshToken = function(force, callback) {
+  var curtime;
+
+  curtime = (new Date().getTime() / 1000);
+
+  if (!force && (curtime < (this._tokenUpdated + this._cacheTokenFor))) {
+    callback(null, this._token);
+    return;
+  }
+
+  this._refreshTokenCompletions.push(callback);
+
+  if (this._refreshTokenCompletions.length === 1) {
+    this._updateToken();
+  }
+};
+
+/**
+ * Update our Service catalog and Auth Token caches.
+ * Notifies this._refreshTokenCompletions on completion or error.
+ */
+KeystoneClient.prototype._updateToken = function() {
+  var options, url, body, self = this;
+
+  options = this._defaultOptions();
+
+  url = sprintf('%s/tokens', this._url);
+  body = {};
+
+  if (this._password) {
+    body = {'auth': {'passwordCredentials': {'username': this._username, 'password': this._password}}};
+  }
+  else {
+    body = {'auth': {'RAX-KSKEY:apiKeyCredentials': {'username': this._username, 'apiKey': this._apiKey}}};
+  }
+
+  function complete(err, result) {
+    var cpl;
+
+    self._tokenUpdated = new Date().getTime() / 1000;
+    cpl = self._refreshTokenCompletions;
+    self._refreshTokenCompletions = [];
+    cpl.forEach(function(func) {
+      func(err, result);
+    });
+  }
+
+  this.emit('log', 'debug', 'Refresing admin token', {'url': this._url});
+
+  request.request(url, 'POST', JSON.stringify(body), options, function(err, result) {
+    var cpl, newToken, newExpires, logObj;
+
+    if (err) {
+      complete(err);
+      return;
+    }
+
+    if (result.body.access) {
+      newToken = result.body.access.token.id;
+      newExpires = result.body.access.token.expires;
+      logObj = {'url': self._url, 'expires': newExpires};
+
+      if (newToken === self._token) {
+        self.emit('log', 'debug', 'Received idential admin token', logObj);
+      }
+      else {
+        self.emit('log', 'debug', 'Received new admin token', logObj);
+      }
+
+      self._token = newToken;
+      self._tokenExpires = newExpires;
+      self._serviceCatalog = result.body.access.serviceCatalog;
+    }
+    else {
+      complete(new Error('Malformed response: ' + JSON.stringify(result)));
+      return;
+    }
+
+    complete(null, self._token);
+  });
+};
+
+/**
+ * Validate a tenantId and token for a user. This method doesn't require
+ * username and api key / password to be provided to the constructor.
+ *
+ * @param {String} tenantId User's tenantId.
+ * @param {String} token User's Token.
+ * @param {Function} callback Callback called with (err, body).
+ */
+KeystoneClient.prototype.validateTokenForTenant = function(tenantId, token, callback) {
+  var self = this, options, url, body;
+
+  body = JSON.stringify({'auth': {'tenantName': tenantId, 'token': {'id': token}}});
+
+  options = this._defaultOptions();
+
+  url = sprintf('%s/tokens/', self._url);
+
+  request.request(url, 'POST', body, options, function(err, result) {
+    var logObj, data, token, tenant;
+
+    if (err) {
+      if ((err instanceof errors.UnexpectedStatusCodeError) && result.body) {
+        logObj = {code: err.statusCode, url: self._url, body: result.body};
+
+        if (err.statusCode === 404) {
+          self.emit('log', 'debug', 'Authentication API returned 404, invalid tenant id or token', logObj);
+        }
+        else if (err.statusCode === 401) {
+          self.emit('log', 'error', 'Authentication API returned 401, invalid admin token (or auth is broken)', logObj);
+        }
+        else {
+          self.emit('log', 'error', 'Authentication API returned an unexpected status code', logObj);
+        }
+      }
+
+      callback(err);
+      return;
+    }
+
+    data = result.body.access;
+
+    if (!data) {
+      callback(new Error('Malformed response: ' + JSON.stringify(result)));
+      return;
+    }
+
+    token = data.token || {};
+    tenant = token.tenant || {};
+
+    if (tenant.id !== tenantId) {
+      // Returned tenant id doesn't match the provided one.
+      callback(new errors.UnexpectedStatusCodeError(KEYSTONE_SUCCESS_STATUS_CODES, 401));
+      return;
+    }
+
+    callback(null, data);
+  });
+};
+
+/**
+ * Validate an auth token without validation the tenant it belongs to.
+ *
+ * @param {String} token User's Token.
+ * @param {Function} callback Callback called with (err, body).
+ */
+KeystoneClient.prototype.validateToken = function(token, callback) {
+  var options = this._defaultOptions(), url = sprintf('%s/tenants', this._url);
+
+  options.headers['X-Auth-Token'] = token;
+
+  request.request(url, 'GET', null, options, function(err, result) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    callback(null, result.body);
+  });
+};
+
+/**
+ * Retrieve information about a TenantId, using the admin token.
+ *
+ * @param {String} tenantId User's tenantId.
+ * @param {Object} options Options object with the following keys:
+ * refreshAuthToken.
+ * @param {Function} callback Completion callback.
+ */
+KeystoneClient.prototype.getTenantInfo = function(tenantId, options, callback) {
+  options = options || {};
+  var url, self = this;
+
+  this._freshToken(options.refreshAuthToken, function() {
+    var reqOptions, qargs;
+
+    reqOptions = self._defaultOptions();
+    reqOptions.headers['X-Auth-Token'] = self._token;
+
+    qargs = querystring.stringify(self._extraArgs);
+
+    url = sprintf('%s/tenants/%s?%s', self._url, tenantId, qargs);
+
+    request.request(url, 'GET', null, reqOptions, function(err, result) {
+      if (err) {
+        if ((err instanceof errors.UnexpectedStatusCodeError) && result.body) {
+          self.emit('log', 'error', 'tenantInfo: Authentication API returned an unexpected status code',
+                    {'code': err.statusCode, 'body': result.body, 'tenantId': tenantId});
+        }
+
+        callback(err);
+        return;
+      }
+
+      if (!result.body.tenant) {
+        callback(new Error('tenantInfo: malformed response: ' + JSON.stringify(result)));
+        return;
+      }
+
+      callback(null, result.body.tenant);
+    });
+  });
+};
+
+/**
+ * Get the service catalog from Keystone.
+ *
+ * @param {Object} options Options object with the following keys:
+ * refreshAuthToken.
+ * @param {Function} callback Completion callback.
+ */
+KeystoneClient.prototype.getServiceCatalog = function(options, callback) {
+  options = options || {};
+  var self = this;
+
+  this._freshToken(options.refreshAuthToken, function(err) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    callback(null, self._serviceCatalog);
+  });
+};
+
+/**
+ * Get the tenant id and token from Keystone for the current username & api key
+ * / password combination.
+ *
+ * @param {Object} options Options object with the following keys:
+ * refreshAuthToken.
+ * @param {Function} callback Completion callback.
+ */
+KeystoneClient.prototype.getTenantIdAndToken = function(options, callback) {
+  options = options || {};
+  var self = this, tenantId;
+
+  this._freshToken(options.refreshAuthToken, function(err) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    self._serviceCatalog.forEach(function(item) {
+      if (item.name === 'cloudServers' || item.name === 'cloudServersLegacy') {
+        if (item.endpoints.length === 0) {
+          throw new Error('Endpoints should always be > 0');
+        }
+
+        tenantId = item.endpoints[0].tenantId;
+      }
+    });
+
+    callback(null, {token: self._token, expires: self._tokenExpires, tenantId: tenantId});
+  });
+};
+
+
+/**
+ * Retrieve a tenant id for the provided cloud username.
+ *
+ * @param {String} username username.
+ * @param {Function} callback Callback called with (err, tenantId).
+ */
+KeystoneClient.prototype.getTenantId = function(username, callback) {
+  var url, options, authStr;
+
+  url = sprintf('%s/users/%s', this._url, username);
+  authStr = new Buffer(this._username + ':' + this._password).toString('base64');
+  options = {
+    'parse_json': true,
+    'expected_status_codes': ['200'],
+    'timeout': 5000,
+    'return_response': true,
+    'headers': {'Accept': 'application/json',
+                'Authorization': 'Basic ' + authStr}
+  };
+
+  request.request(url, 'GET', null, options, function(err, result) {
+    var tenantId;
+    if (err) {
+      callback(err, null);
+      return;
+    }
+
+    tenantId = result.body.user.mossoId;
+    callback(null, tenantId);
+  });
+};
+
+exports.KeystoneClient = KeystoneClient;

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/.npmignore
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/.travis.yml
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+node_js:
+  - 0.6
+
+before_script: npm run-script lint
+script: npm run-script lint
+
+notifications:
+  email:
+    - tomaz+travisci@tomaz.me

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/LICENSE
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/README.md
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/README.md
@@ -1,0 +1,12 @@
+# Rackspace Utility Functions
+
+Shared Rackspace Node.js utility modules and functions.
+
+# Build status
+
+[![Build Status](https://secure.travis-ci.org/racker/node-rackspace-shared-utils.png)](http://travis-ci.org/racker/node-rackspace-shared-utils)
+
+
+# License
+
+This library is distributed under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/jshint.json
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/jshint.json
@@ -1,0 +1,18 @@
+{
+    "maxerr"        : 100,
+    "node"          : true,
+    "curly"         : true,
+    "eqeqeq"        : true,
+    "latedef"       : false,
+    "undef"         : true,
+    "newcap"        : true,
+    "nonew"         : true,
+    "onevar"        : false,
+    "trailing"      : true,
+    "white"         : false,
+    "sub"           : true,
+    "evil"          : true,
+    "es5"           : true,
+    "onecase"       : true,
+    "strict"        : false
+}

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/errors.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/errors.js
@@ -1,0 +1,59 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var util = require('util');
+
+var sprintf = require('sprintf').sprintf;
+
+/**
+ * UnexpectedStatusCodeError class.
+ *
+ * @constructor
+ * @param {Array} expectedStatusCodes Expected status code.
+ * @param {Number} actualStatusCode Actual status code.
+ */
+function UnexpectedStatusCodeError(expectedStatusCodes, actualStatusCode) {
+  var msg = sprintf('Unexpected status code "%s". Expected one of: %s', actualStatusCode,
+                    expectedStatusCodes.join(', '));
+
+  this.expectedStatusCodes = expectedStatusCodes;
+  this.statusCode = actualStatusCode;
+  this.message = msg;
+  Error.call(this, msg);
+  Error.captureStackTrace(this, this.constructor);
+}
+
+util.inherits(UnexpectedStatusCodeError, Error);
+
+exports.UnexpectedStatusCodeError = UnexpectedStatusCodeError;
+
+
+/**
+ * An error class which represents a validation failure.
+ * @constructor
+ *
+ * @param {String} message Error message.
+ */
+function ValidationFailureError(message) {
+  this.message = message;
+  Error.call(this, message);
+  Error.captureStackTrace(this, this.constructor);
+}
+
+util.inherits(ValidationFailureError, Error);
+
+exports.ValidationFailureError = ValidationFailureError;

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/flow_control.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/flow_control.js
@@ -1,0 +1,124 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var async = require('async');
+
+
+/**
+ * Default number of retries.
+ * @type {Number}
+ * @const
+ */
+var DEFAULT_FLOW_MAX_RETRIES = 3;
+
+
+/**
+ * Wrap a function so that the original function will only be called once,
+ * regardless of how  many times the wrapper is called.
+ * @param {Function} fn The to wrap.
+ * @return {Function} A function which will call fn the first time it is called.
+ */
+exports.fireOnce = function(fn) {
+  var fired = false;
+  return function wrapped() {
+    if (!fired) {
+      fired = true;
+      fn.apply(null, arguments);
+    }
+  };
+};
+
+
+/**
+ * Wraps a callback and only passes args to it if err is null / undefined.
+ *
+ * @param {Function} callback Callback to wrap.
+ * @param {Array} args Arguments which are passed to callback if !err.
+ * @param {Bool} includeExtra true to include arguments which are passed to the
+ * callback after err.
+ * @return {Function} Wrapped callback.
+ */
+exports.wrapCallback = function(callback, args, includeExtra) {
+  includeExtra = includeExtra || false;
+  return function(err) {
+    var callbackArgs = [null], i = 1, len = arguments.length;
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    callbackArgs = callbackArgs.concat(args);
+
+    if (includeExtra) {
+      while (i < len) {
+        callbackArgs.push(arguments[i]);
+        i++;
+      }
+    }
+
+    callback.apply(null, callbackArgs);
+  };
+};
+
+
+/**
+ * Calls a function and retries if a callback gets passed an error.
+ *
+ * @param {Function} func Function to call. This function must take callback as
+ * the last argument.
+ * @param {Object} scope Scope in which function is called.
+ * @param {Array} args Arguments with which the function should be called.
+ * @param {Object} options Function options (max_retries, ...).
+ * @param {Function} callback A callback called with (err).
+ */
+exports.retryOnError = function(func, scope, args, options, callback) {
+  args = args || [];
+  options = options || {};
+  scope = scope || null;
+  var retries = 0, done = false, funcErr = null,
+      maxRetries = (options.max_retries || DEFAULT_FLOW_MAX_RETRIES) + 1;
+
+  async.whilst(function test() {
+    return (retries < maxRetries) && !done;
+  },
+
+  function runTask(callback) {
+    var funcArgs;
+    function wrappedCallback(err) {
+      if (!err) {
+        done = true;
+      }
+
+      funcErr = err;
+      callback();
+    }
+
+    funcArgs = args.concat(wrappedCallback);
+
+    retries++;
+    try {
+      func.apply(scope, funcArgs);
+    } catch (err) {
+      callback();
+      return;
+    }
+  },
+
+  function onEnd(err) {
+    callback(funcErr);
+  });
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/fs.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/fs.js
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var async = require('async');
+
+
+/**
+ * Open a file while allowing for retries
+ *
+ * @param {String} file file name.
+ * @param {Number} maxRetries number of maximum retries before it gives up.
+ * @param {Number} delay delay between retries.
+ * @param {Function} callback Callback called with (err, fd).
+ */
+exports.openFileWithRetries = function(file, maxRetries, delay, callback) {
+  var retries = 0, fdOut, lastErr, done = false;
+  async.whilst(
+      function() {
+        return ((retries < maxRetries) && (!done));
+      },
+
+      function(callback) {
+        fs.open(file, 'r', function(err, fd) {
+          lastErr = err;
+          if (err) {
+            retries = retries + 1;
+            setTimeout(callback, delay);
+            return;
+          } else {
+            done = true;
+            lastErr = undefined;
+            fdOut = fd;
+            callback();
+            return;
+          }
+        });
+      },
+
+      function(err) {
+        callback(lastErr, fdOut);
+      }
+  );
+};
+
+
+/**
+ * Get files in a directory which match the provided name pattern.
+ * Note: This function recurses into sub-directories.
+ *
+ * @param {String} directory Directory to search.
+ * @param {String} matchPattern File name match pattern.
+ * @param {Object} options Optional options object.
+ * @param {Function} callback Callback called with (err, matchingFilePaths).
+ */
+exports.getMatchingFiles = function getMatchingFiles(directory, matchPattern, options, callback) {
+  options = options || {};
+  var matchedFiles = [],
+      recurse = options.recurse || false;
+
+  fs.readdir(directory, function(err, files) {
+    if (err) {
+      callback(null, matchedFiles);
+      return;
+    }
+
+    async.forEach(files, function(file, callback) {
+      var filePath = path.join(directory, file);
+      fs.stat(filePath, function(err, stats) {
+        if (err) {
+          callback();
+        }
+        else if (stats.isDirectory() && recurse) {
+          getMatchingFiles(filePath, matchPattern, options, callback);
+        }
+        else if (matchPattern.test(file)) {
+          matchedFiles.push(filePath);
+          callback();
+        }
+        else {
+          callback();
+        }
+      });
+    },
+
+    function(err) {
+      callback(err, matchedFiles);
+    });
+  });
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/index.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/index.js
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var misc = require('./misc');
+
+['errors', 'flow_control', 'fs', 'instruments', 'misc', 'request'].forEach(function(module) {
+  var name = misc.toCamelCase(module);
+  exports[name] = require('./' + module);
+});

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/instruments.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/instruments.js
@@ -1,0 +1,350 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var util = require('util');
+
+var Timer = require('metrics-ck').Timer;
+var Counter = require('metrics-ck').Counter;
+var Meter = require('metrics-ck').Meter;
+
+
+/**
+ * Storage for live metrics.
+ */
+var workMetrics = {};
+var eventMetrics = {};
+
+
+/**
+ * Used when metrics are disabled.
+ */
+function noop() {}
+
+
+/**
+ * Instantiate a work metric if it doesn't exist.
+ * @param {String} label The metric to instantiate.
+ */
+function ensureWorkMetric(label) {
+  if (!workMetrics[label]) {
+    workMetrics[label] = {
+      active: new Counter(),
+      timer: new Timer(),
+      errorMeter: new Meter()
+    };
+  }
+}
+
+
+/**
+ * Record work directly, skipping active counter.
+ * @param {String} label The label for the work.
+ * @param {Number} duration The duration of the work in ms.
+ */
+exports.measureWork = function(label, duration) {
+  ensureWorkMetric(label);
+  workMetrics[label].timer.update(duration);
+};
+
+
+/**
+ * Record the occurrence of an event.
+ * @param {String} label A label identifying the event.
+ */
+exports.recordEvent = function(label) {
+  if (!eventMetrics[label]) {
+    eventMetrics[label] = new Meter();
+  }
+
+  eventMetrics[label].mark(1);
+};
+
+
+
+/**
+ * Used to track when work starts/stops across method invocations.
+ * @constructor
+ * @param {string} label the metric that will be tracked.
+ */
+function Work(label) {
+  this.label = label;
+  this.startTime = null;
+  this.stopTime = null;
+  ensureWorkMetric(this.label);
+}
+
+
+/**
+ * Start measuring work.
+ */
+Work.prototype.start = function() {
+  this.startTime = Date.now();
+  workMetrics[this.label].active.inc();
+};
+
+
+/**
+ * Stop measuring work and record it.
+ * @param {boolean} error Whether an error occurred.
+ * @return {Number} Number of seconds between stop and start call.
+ */
+Work.prototype.stop = function(error) {
+  var delta;
+
+  this.stopTime = Date.now();
+
+  delta = (this.stopTime - this.startTime);
+  workMetrics[this.label].active.dec();
+  workMetrics[this.label].timer.update(delta);
+
+  if (error) {
+    workMetrics[this.label].errorMeter.mark(1);
+  }
+
+  return delta;
+};
+
+
+
+/**
+ * Dummy work object. Each method call is a no-op.
+ * @constructor
+ * @param {{string}} label the metric that will be tracked.
+ */
+function DummyWork(label) {}
+
+util.inherits(DummyWork, Work);
+
+
+/** no-op. */
+DummyWork.prototype.start = noop;
+
+
+/** no-op. */
+DummyWork.prototype.stop = noop;
+
+
+/**
+ * Retrieve a specific work metric.
+ * @param {String} label The label of the metric to retrieve.
+ * @return {Object} The work metric data.
+ */
+exports.getWorkMetric = function(label) {
+  var metric = workMetrics[label], pct;
+
+  if (metric) {
+    pct = metric.timer.percentiles([0.01, 0.25, 0.5, 0.75, 0.99]);
+    return {
+      label: label,
+      ops_count: metric.timer.count(),
+      rate_1m: metric.timer.oneMinuteRate(),
+      rate_5m: metric.timer.fiveMinuteRate(),
+      rate_15m: metric.timer.fifteenMinuteRate(),
+      mean_rate: metric.timer.meanRate(),
+      min: metric.timer.min(),
+      max: metric.timer.max(),
+      mean_time: metric.timer.mean(),
+      std_dev: metric.timer.stdDev(),
+      pct_1: pct['0.01'],
+      pct_25: pct['0.25'],
+      pct_50: pct['0.5'],
+      pct_75: pct['0.75'],
+      pct_99: pct['0.99'],
+      active: metric.active.count,
+      errors: metric.errorMeter.count,
+      err_rate_1m: metric.errorMeter.oneMinuteRate(),
+      err_rate_5m: metric.errorMeter.fiveMinuteRate(),
+      err_rate_15m: metric.errorMeter.fifteenMinuteRate(),
+      err_mean_rate: metric.errorMeter.meanRate()
+    };
+  } else {
+    return {
+      label: label,
+      ops_count: 0,
+      rate_1m: 0,
+      rate_5m: 0,
+      rate_15m: 0,
+      mean_rate: 0,
+      min: 0,
+      max: 0,
+      mean_time: 0,
+      std_dev: 0,
+      pct_1: 0,
+      pct_25: 0,
+      pct_50: 0,
+      pct_75: 0,
+      pct_99: 0,
+      active: 0,
+      errors: 0,
+      err_rate_1m: 0,
+      err_rate_5m: 0,
+      err_rate_15m: 0,
+      err_mean_rate: 0
+    };
+  }
+};
+
+
+/**
+ * Get all work metrics.
+ * @return {Array} A list of work metrics.
+ */
+exports.getWorkMetrics = function() {
+  var metrics = [], key;
+
+  for (key in workMetrics) {
+    if (workMetrics.hasOwnProperty(key)) {
+      metrics.push(exports.getWorkMetric(key));
+    }
+  }
+  return metrics;
+};
+
+
+/**
+ * Retrieve metrics for a specific event.
+ * @param {String} label The event to retrieve metrics for.
+ * @return {Object} The event metric data.
+ */
+exports.getEventMetric = function(label) {
+  var metric = eventMetrics[label];
+
+  if (metric) {
+    return {
+      label: label,
+      count: metric.count,
+      rate_1m: metric.oneMinuteRate(),
+      rate_5m: metric.fiveMinuteRate(),
+      rate_15m: metric.fifteenMinuteRate(),
+      rate_mean: metric.meanRate()
+    };
+  } else {
+    return {
+      label: label,
+      count: 0,
+      rate_1m: 0,
+      rate_5m: 0,
+      rate_15m: 0,
+      rate_mean: 0
+    };
+  }
+};
+
+
+/**
+ * Get all event metrics.
+ * @return {Array} A list of event metrics.
+ */
+exports.getEventMetrics = function() {
+  var metrics = [], key;
+
+  for (key in eventMetrics) {
+    if (eventMetrics.hasOwnProperty(key)) {
+      metrics.push(exports.getEventMetric(key));
+    }
+  }
+  return metrics;
+};
+
+
+/**
+ * Get all metrics. This is fairly expensive, if you know what you want then
+ * you should get that directly.
+ * @return {Object} A map of metric types to metric lists.
+ */
+exports.getMetrics = function() {
+  return {
+    work: exports.getWorkMetrics(),
+    events: exports.getEventMetrics()
+  };
+};
+
+
+/** the work function. */
+exports.Work = Work;
+
+
+/** DummyWork class. */
+exports.DummyWork = DummyWork;
+
+
+/**
+ * The metrics library calls setInterval but never clears it. This causes
+ * tests, among other things, to hang. Traverse the object hierarchy, find the
+ * interval (which has a specific name) and clear it.
+ * @param {Object} obj The object to clear intervals from.
+ */
+function clearStrayIntervals(obj) {
+  var field;
+
+  for (field in obj) {
+    if (field === '0') {
+      continue;
+    } else if (field === 'tickInterval') {
+      clearInterval(obj[field]);
+    } else {
+      clearStrayIntervals(obj[field]);
+    }
+  }
+}
+
+
+/**
+ * Release resources being used to track an operation.
+ * @param {String} label A label identifying which resources to release.
+ */
+exports.releaseWork = function(label) {
+  clearStrayIntervals(workMetrics[label].timer);
+  clearStrayIntervals(workMetrics[label].errorMeter);
+  delete workMetrics[label];
+};
+
+
+/**
+ * Release resources being used to track an event.
+ * @param {String} label A label identifying which resources to release.
+ */
+exports.releaseEvent = function(label) {
+  clearStrayIntervals(eventMetrics[label]);
+  delete eventMetrics[label];
+};
+
+
+/**
+ * Release all resources.
+ *
+ * @param {Function} callback the completion callback.
+ */
+exports.shutdown = function(callback) {
+  var label;
+
+  callback = callback || noop;
+
+  for (label in workMetrics) {
+    if (workMetrics.hasOwnProperty(label)) {
+      exports.releaseWork(label);
+    }
+  }
+
+  for (label in eventMetrics) {
+    if (eventMetrics.hasOwnProperty(label)) {
+      exports.releaseEvent(label);
+    }
+  }
+
+  callback();
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/misc.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/misc.js
@@ -1,0 +1,719 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var sprintf = require('sprintf').sprintf;
+
+
+/**
+ * Regular expression object cache.
+ * @type {Object}.
+ */
+var REGEXP_CACHE = {};
+
+
+/**
+ * Figure the boolean XOR function, since JavaScript doesn't have it.
+ * @param {Boolean} a First param.
+ * @param {Boolean} b Second param.
+ * @return {Boolean} Logical XOR.
+ */
+exports.logicalXOR = function(a, b) {
+  return ((a || b) && !(a && b));
+};
+
+
+/**
+ * Generate a random number between lower and upper bound.
+ *
+ * @param {Number} min Lower bound.
+ * @param {Number} max Upper bound.
+ * @return {Number} Random number between lower and upper bound.
+ */
+exports.getRandomInt = function(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+
+/**
+ * Generate a random string of upper lower case letters and decimal digits.
+ *
+ * @param {Number} len  The length of the string to return;.
+ * @return {String} Random string.
+ */
+exports.randstr = function(len) {
+  var chars, r, x;
+
+  chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  r = [];
+
+  for (x = 0; x < len; x++) {
+    r.push(chars[exports.getRandomInt(0, chars.length - 1)]);
+  }
+
+  return r.join('');
+};
+
+
+/**
+ * Trim leading and trailing whitespace from a string.
+ *
+ * @param {String} text Original String.
+ * @return {string} String with trimmed whitespace.
+ */
+exports.trim = function trim(text) {
+  return (text || '').replace(/^\s+|\s+$/g, '');
+};
+
+
+/**
+ * Very simple object merging.
+ * Merges two or more objects together, returning the first object containing a
+ * superset of all attributes.  There is a hiearchy of precedence starting with
+ * left side and moving right.
+ *
+ * @return {Object} The merged object.
+ */
+exports.fullMerge = function() {
+  var args = Array.prototype.slice.call(arguments),
+      first,
+      a,
+      attrname,
+      i, l;
+
+  if (args.length < 2) {
+    throw new Error('Incorrect use of the API, use at least two operands');
+  }
+
+  first = args[0];
+
+  for (i = 1, l = args.length; i < l; i++) {
+    a = args[i];
+    for (attrname in a) {
+      if (a.hasOwnProperty(attrname)) {
+        first[attrname] = a[attrname];
+      }
+    }
+  }
+  return first;
+};
+
+
+/**
+ * Very simple object merging.
+ * Merges two objects together, returning a new object containing a
+ * superset of all attributes.  Attributes in b are prefered if both
+ * objects have identical keys.
+ *
+ * @param {Object} a Object to merge.
+ * @param {Object} b Object to merge, wins on conflict.
+ * @return {Object} The merged object.
+ */
+exports.merge = function(a, b) {
+  return exports.fullMerge({}, a, b);
+};
+
+
+/**
+ * Returns unique elements in an array.  The elements of the source array
+ * should be strings or numbers; the results are undefined if the array
+ * contains objects.
+ *
+ * @param {Array} src Source array.
+ * @return {Array} A copy of the source array, with duplicate elements removed.
+ */
+exports.unique = function(src) {
+  var i,
+      elem,
+      hash = {},
+      result = [];
+
+  for (i = 0; i < src.length; i = i + 1) {
+    hash[src[i]] = src[i];
+  }
+  for (elem in hash) {
+    if (hash.hasOwnProperty(elem)) {
+      result.push(hash[elem]);
+    }
+  }
+  return result;
+};
+
+
+/**
+ * Reverse version of the Object.keys method.
+ *
+ * @param {Object} object from which the values should be extracted.
+ * @return {Array} All the values.
+ */
+exports.getValues = function(object) {
+  var key,
+      values = [];
+
+  for (key in object) {
+    if (object.hasOwnProperty(key)) {
+      values.push(object[key]);
+    }
+  }
+
+  return values;
+};
+
+
+/**
+ * Escape characters in a string which Javascript RegExp object considers as special.
+ *
+ * @param {String} string Input string.
+ * @return {String} String with all the special characters escaped.
+ */
+exports.escapeRegexpString = function(string) {
+  var regexp = new RegExp('[.*+?|()\\[\\]{}\\\\\\$]', 'g');
+
+  return string.replace(regexp, '\\$&');
+};
+
+
+/**
+ * Prefix a string with (level * chr) indentation characters.
+ *
+ * @param {String} str String to indent.
+ * @param {Number} level Current nesting level.
+ * @param {?String} chr Character which is used for indentation. Defaults to
+ * 4 spaces ('    ').
+ * @return {String} Indented string.
+ */
+function indent(str, level, chr) {
+  chr = chr || '    ';
+  var newStr = '', i = 0, j = 0;
+
+  while (i < level) {
+    newStr += chr;
+    i++;
+  }
+
+  newStr += str;
+  return newStr;
+}
+
+
+/**
+ * Randomly select an IP address and port from a poll of the addresses.
+ *
+ * @param {Array} addresses An array from which a random member will be
+ *                          selected.
+ * @return {Array} [ip, address] pair.
+ */
+function getRandomAddress(addresses) {
+  var index = exports.getRandomInt(0, addresses.length - 1),
+      address = addresses[index];
+
+  return exports.splitAddress(address);
+}
+
+
+/**
+ * Display a backtrace.
+ */
+exports.backtrace = function() {
+  console.log(new Error('Backtrace').stack);
+};
+
+
+/**
+ * Reverse of Object.keys.
+ *
+ * @param {Object} obj Object to reverse.
+ * @return {Object} Reversed object.
+ */
+exports.reverseObject = function(obj) {
+  var newObj = {},
+      key, value;
+
+  for (key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      value = obj[key];
+      newObj[value] = key;
+    }
+  }
+
+  return newObj;
+};
+
+
+/**
+ * Splice and return a random element from an array.
+ * @param {Array} elements The array from which to splice.
+ * @return {Object} The element spliced from the array.
+ */
+exports.spliceRandomElement = function(elements) {
+  var idx = exports.getRandomInt(0, elements.length - 1);
+  return elements.splice(idx, 1)[0];
+};
+
+
+/**
+ * Split a host:port address into a host and port. This is basically python's
+ * 'rpslit'.
+ * @param {String} addr The address to split.
+ * @return {Array} A [host, port] pair.
+ */
+exports.splitAddress = function(addr) {
+  var idx = addr.lastIndexOf(':');
+
+  if (idx === -1) {
+    throw new Error('Address does not contain a colon (:)');
+  }
+
+  return [addr.slice(0, idx), addr.slice(idx + 1)];
+};
+
+
+/**
+ * Construct a new object of type klass.
+ * @param {Function} klass Class to construct.
+ * @param {Array} args Arguments which are passed to the constructor.
+ * @return {Object} A new instance of 'klass'.
+ */
+exports.construct = function(klass, args) {
+  var obj = Object.create(klass.prototype);
+  klass.apply(obj, args);
+  return obj;
+};
+
+
+/**
+ * indent function.
+ */
+exports.indent = indent;
+
+
+/**
+ * getRandomAddress function.
+ */
+exports.getRandomAddress = getRandomAddress;
+
+
+function strip(str) {
+  return str.replace(/^\s+|\s+$/g, '');
+}
+
+
+/** Convert arguments from the commandline to a javascript object
+ *
+ * @param {Object} args an array of parameters.
+ * @return {Object} a converted object.
+ */
+exports.argsToObject = function(args) {
+  var obj = {}, tmp, v, i, key, t;
+
+  args.forEach(function(data) {
+    /* parse for key/value pairs */
+    v = data.split('=');
+    key = strip(v[0]);
+    if (v[1][0] === '[') {
+      /* arrays */
+      tmp = v[1].substring(1, v[1].length - 1).split(',');
+      obj[key] = [];
+      for (i = 0; i < tmp.length; i++) {
+        /* strip string and push onto the array */
+        obj[key].push(strip(tmp[i]));
+      }
+    } else if (v[1][0] === '{') {
+      /* arrays */
+      tmp = v[1].substring(1, v[1].length - 1).split(',');
+      obj[key] = {};
+      for (i = 0; i < tmp.length; i++) {
+        t = tmp[i].split(':');
+        /* strip string and push onto the array */
+        obj[key][strip(t[0])] = strip(t[1]);
+      }
+    } else {
+      /* parse for key value pairs */
+      obj[key] = strip(v[1]);
+    }
+  });
+  return obj;
+};
+
+
+/**
+ * convert a buffer to a 32bit uint
+ * @param {Buffer} buffer to operate on.
+ * @param {Int} offset start the buffer on.
+ * @param {String} endian to use during conversion.
+ * @return {Int} val the value.
+ */
+exports.bufferToUint32 = function(buffer, offset, endian) {
+  var val;
+
+  if (endian === 'big') {
+    val = buffer[offset + 1] << 16;
+    val |= buffer[offset + 2] << 8;
+    val |= buffer[offset + 3];
+    val = val + (buffer[offset] << 24 >>> 0);
+  } else {
+    val = buffer[offset + 2] << 16;
+    val |= buffer[offset + 1] << 8;
+    val |= buffer[offset];
+    val = val + (buffer[offset + 3] << 24 >>> 0);
+  }
+  return val;
+};
+
+
+/**
+ * convert a 32bit int to a buffer
+ * @param {Int} value to convert to buffer.
+ * @param {Buffer} buffer to operate on.
+ * @param {Int} offset start the buffer on.
+ * @param {String} endian to use during conversion.
+ */
+exports.uint32ToBuffer = function(value, buffer, offset, endian) {
+  if (endian === 'big') {
+    buffer[offset] = (value >>> 24) & 0xff;
+    buffer[offset + 1] = (value >>> 16) & 0xff;
+    buffer[offset + 2] = (value >>> 8) & 0xff;
+    buffer[offset + 3] = value & 0xff;
+  } else {
+    buffer[offset + 3] = (value >>> 24) & 0xff;
+    buffer[offset + 2] = (value >>> 16) & 0xff;
+    buffer[offset + 1] = (value >>> 8) & 0xff;
+    buffer[offset] = value & 0xff;
+  }
+};
+
+
+/** XML Escape a String.
+ * @param {String} str The string for convert.
+ * @return {String} The converted string.
+ */
+exports.escapeXML = function(str) {
+  return str.replace('"', '&quote;')
+    .replace('\'', '&apos;')
+    .replace('<', '&lt;')
+    .replace('>', '&gt;')
+    .replace('&', '&amp;');
+};
+
+
+/**
+ * Return unix timestamp
+ *
+ * @param  {Date} date Date object to convert to Unix timestamp. If no date is
+                       provided, current time is used.
+ * @return {Number} Number of seconds passed from Unix epoch.
+ */
+exports.getUnixTimestamp = function(date) {
+  var dateToFormat = date || new Date();
+
+  return Math.round(dateToFormat / 1000);
+};
+
+
+/**
+ * Convert a date string to unix timestamp.
+ *
+ * @param {String} dateStr Date and time string.
+ * @return {Number} Number of seconds since unix epoch.
+ */
+exports.dateStrToUnixTimestamp = function(dateStr) {
+  return Math.round((Date.parse(dateStr) / 1000));
+};
+
+
+/** Functions bellow are take from Nodejs code base. */
+
+
+/**
+ * Check if two objects are equal.
+ *
+ * @param {Object|Array} a Object 1.
+ * @param {Object|Array} b Object 2.
+ * @return {Boolean} true / false.
+ */
+exports.deepEqual = function deepEqual(a, b) {
+  var i;
+
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (a === b) {
+    return true;
+
+  } else if (Buffer.isBuffer(a) && Buffer.isBuffer(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    for (i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) {
+        return false;
+      }
+    }
+
+    return true;
+
+  // 7.2. If the expected value is a Date object, the actual value is
+  // equivalent if it is also a Date object that refers to the same time.
+  } else if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+
+  // 7.3. Other pairs that do not both pass typeof value == 'object',
+  // equivalence is determined by ==.
+  } else if (typeof a !== 'object' && typeof b !== 'object') {
+    return a === b;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical 'prototype' property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return exports.objEquiv(a, b);
+  }
+};
+
+
+/**
+ * Check if value is null or undefined.
+ *
+ * @param {*} value Value to check.
+ * @return {Boolean} true / false.
+ */
+function isUndefinedOrNull(value) {
+  return value === null || value === undefined;
+}
+
+
+/**
+ * Check if object is an arguments object.
+ *
+ * @param {Object} object Object to check.
+ * @return {Boolean} true / false.
+ */
+function isArguments(object) {
+  return Object.prototype.toString.call(object) === '[object Arguments]';
+}
+
+
+/**
+ * Check if two objects are equal.
+ *
+ * @param {Object|Array} a Object 1.
+ * @param {Object|Array} b Object 2.
+ * @return {Boolean} true / false.
+ */
+exports.objEquiv = function objEquiv(a, b) {
+  var ka, kb, key, i;
+
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b)) {
+    return false;
+  }
+
+  // an identical 'prototype' property.
+  if (a.prototype !== b.prototype) {
+    return false;
+  }
+
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = Array.prototype.slice.call(a);
+    b = Array.prototype.slice.call(b);
+    return exports.deepEqual(a, b);
+  }
+  try {
+    ka = Object.keys(a);
+    kb = Object.keys(b);
+  } catch (e) {//happens when one is a string literal and the other isn't
+    return false;
+  }
+  // having the same number of owned properties (keys incorporates
+  // hasOwnProperty)
+  if (ka.length !== kb.length) {
+    return false;
+  }
+
+  //the same set of keys (although not necessarily the same order),
+  ka.sort();
+  kb.sort();
+  //~~~cheap key test
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] !== kb[i]) {
+      return false;
+    }
+  }
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!exports.deepEqual(a[key], b[key])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+
+/**
+ * Quote a string so it can be used in the shell command.
+ *
+ * @param {String} string String to quote.
+ * @return {String} Quoted string.
+ */
+exports.shellQuote = function(string) {
+  var quoted;
+
+  if (typeof string !== 'string') {
+    string = string.toString();
+  }
+
+  quoted = "'" + string.replace(/'/g, '"\'"') + "'";
+  return quoted;
+};
+
+
+/**
+ * Change a hash to a sorted list of objects with name, value as the attributes.
+ * @param {Object} hash to operate on.
+ * @return {List} an array of sorted hashes.
+ */
+exports.sortHash = function(hash) {
+  var keys, i, l,
+      container = [];
+
+  keys = Object.keys(hash).sort();
+  for (i = 0, l = keys.length; i < l; i++) {
+    container[i] = { name: keys[i], value: hash[keys[i]] };
+  }
+  return container;
+};
+
+
+/**
+ * prints and sets an exit code for nagios checks..
+ * @param {String} service name of the process.
+ * @param {String} state of the process, OK, WARNING, CRITICAL, UNKNOWN.
+ * @param {String} msg about the service claim.
+ */
+exports.printStatusAndExit = function(service, state, msg) {
+  var exitCode = 0;
+
+  console.log('%s %s %s', state, service, msg.substring(0, 70));
+
+  if (state === 'OK') {
+    exitCode = 0;
+  }
+  else if (state === 'WARNING') {
+    exitCode = 1;
+  }
+  else if (state === 'CRITICAL') {
+    exitCode = 2;
+  }
+  else {
+    exitCode = 3;
+  }
+
+  process.exit(exitCode);
+};
+
+
+/**
+ * Return RFC3339 date string.
+ *
+ * @param {Date} date Date object.
+ * @return {String} RFC339 formatted date string.
+ */
+exports.toRfc3339Date = function(date) {
+  var str, values;
+
+  function addZero(num) {
+    if (num < 10) {
+      return '0' + num;
+    }
+
+    return num;
+  }
+
+  values = {
+    'year': date.getUTCFullYear(),
+    'month': addZero(date.getUTCMonth() + 1),
+    'day': addZero(date.getUTCDate()),
+    'hours': addZero(date.getUTCHours()),
+    'minutes': addZero(date.getUTCMinutes()),
+    'seconds': addZero(date.getUTCSeconds())
+  };
+
+  return sprintf('%(year)s-%(month)s-%(day)sT%(hours)s:%(minutes)s:%(seconds)sZ', values);
+};
+
+
+/**
+ * Bind a string with the provided values.
+ *
+ * @param {Object} placeholderMap Object which maps key in the values Object to
+ * the placeholder name.
+ * @param {String} string String to bind.
+ * @param {Object} values Object with the values used for binding.
+ * @return {String} bound string.
+ */
+exports.bindString = function bindString(placeholderMap, string, values) {
+  var key, placeholder, value, regexp;
+
+  for (key in values) {
+    if (values.hasOwnProperty(key)) {
+      placeholder = placeholderMap[key];
+      value = values[key];
+
+      if (!REGEXP_CACHE.hasOwnProperty(key)) {
+        REGEXP_CACHE[key] = new RegExp(exports.escapeRegexpString(placeholder), 'g');
+      }
+
+      regexp = REGEXP_CACHE[key];
+
+      string = string.replace(regexp, value);
+    }
+  }
+
+  return string;
+};
+
+
+/**
+ * Convert a string from underscore separated to camelCase format.
+ *
+ * @param {String} string String to convert.
+ * @return {String} Converted string.
+ */
+exports.toCamelCase = function toCamelCase(string) {
+  var components = string.split('_'), i = 0, result = string;
+
+  if (components.length > 0) {
+    result = '';
+    components.forEach(function(component) {
+      if (i === 0) {
+        result += component;
+      } else {
+        result += component[0].toUpperCase() + component.slice(1);
+      }
+      i++;
+    });
+  }
+
+  return result;
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/request.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/request.js
@@ -1,0 +1,300 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var parse = require('url').parse;
+var http = require('http');
+var https = require('https');
+var constants = require('constants');
+
+var sprintf = require('sprintf').sprintf;
+var async = require('async');
+
+var misc = require('./misc');
+var UnexpectedStatusCodeError = require('./errors').UnexpectedStatusCodeError;
+
+
+/**
+ * Check a status code versus a variant array.
+ *
+ * @param {Integer, String, RegExp} statusCode the status code to check.
+ * @param {Array<Integer, String, RegExp>} expectedStatusCodes list of list of mixed status Codes.
+ * @return {Boolean} true/false depending on a match.
+ */
+exports.checkStatusCodes = function(statusCode, expectedStatusCodes) {
+  var i,
+      comparator;
+
+  for (i = 0; i < expectedStatusCodes.length; i++) {
+    comparator = expectedStatusCodes[i];
+    if (comparator instanceof RegExp) {
+      if (statusCode.toString().match(comparator)) {
+        return true;
+      }
+    } else if (typeof comparator === 'string' || comparator instanceof String) {
+      if (comparator === statusCode.toString()) {
+        return true;
+      }
+    } else {
+      if (comparator === statusCode) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+
+/** Generate Authentication Header
+ * @param {String} username The Username.
+ * @param {String} password The Password.
+ * @return {String} The header string for authentication.
+ */
+exports.getAuthHeader = function(username, password) {
+  var auth;
+
+  if (!username || !password) {
+    throw new Error('Missing username or password');
+  }
+
+  auth = 'Basic ' + new Buffer(username + ':' + password).toString('base64');
+  return auth;
+};
+
+
+/**
+ * Build a cURL command with the provided options.
+ *
+ * @param {String} url target url.
+ * @param {String} method HTTP methpd (get, post, put, etc.).
+ * @param {Object} headers Request headers.
+ * @param {?String} body Optional body.
+ * @return {String} cURL command.
+ */
+exports.buildCurlCommand = function(url, method, headers, body) {
+  var key, value, parts = ['curl', '-i'];
+
+  parts.push('-X');
+  parts.push(misc.shellQuote(method.toUpperCase()));
+
+  for (key in headers) {
+    if (headers.hasOwnProperty(key)) {
+      value = headers[key];
+
+      if (key.toLowerCase() === 'content-length' && parseInt(value, 10) === 0) {
+        continue;
+      }
+
+      parts.push('-H');
+      parts.push(misc.shellQuote(sprintf('%s: %s', key, value)));
+    }
+  }
+
+  if (body) {
+    parts.push('--data-binary');
+    parts.push(misc.shellQuote(body));
+  }
+
+  parts.push(misc.shellQuote(url));
+
+  return parts.join(' ');
+};
+
+
+/**
+ * Perform an HTTP request to the specified URL.
+ *
+ * @param {String} url target url.
+ * @param {String} method HTTP methpd (get, post, put, etc.).
+ * @param {?String} body Optional body.
+ * @param {Object} options Different request options.
+ * @param {Function} callback Callback called with (err, result).
+ */
+function request(url, method, body, options, callback) {
+  body = body || '';
+  var defaultOptions = {
+    'parse_json': false, // Parse body as JSON
+    'expected_status_codes': [], // Array of expected status codes, each element can be either
+                         // a _string, number or regexp_
+    'username': null, // Optional username for basic auth
+    'password': null, // Optional password for basic auth
+    'headers': {}, // Optional request headers.
+    'timeout': 20000, // request timeout in milliseconds,
+    'return_response': false, // wait for body and return response object even if an unexpected status code is returned
+    'hooks': {},
+
+    'key': null,
+    'cert': null
+  },
+      reqOptions, reqFunc, auth, req, customAgent = false,
+      agent = false, ssl = false, parsed = parse(url);
+
+  options = misc.merge(defaultOptions, options);
+
+  if (parsed.protocol === 'https:') {
+    ssl = true;
+    reqFunc = https.request.bind(https);
+  }
+  else {
+    ssl = false;
+    reqFunc = http.request.bind(http);
+  }
+
+  reqOptions = {
+    host: parsed.hostname || parsed.host,
+    path: parsed.pathname + (parsed.search || ''),
+    method: method,
+    headers: options.headers
+  };
+
+  if (parsed.port) {
+    reqOptions.port = parseInt(parsed.port, 10);
+  }
+  else {
+    reqOptions.port = (parsed.protocol === 'https:') ? 443 : 80;
+  }
+
+  if (options.key) {
+    customAgent = true;
+    reqOptions.key = options.key;
+  }
+
+  if (options.cert) {
+    customAgent = true;
+    reqOptions.cert = options.cert;
+  }
+
+  // Add content-length (if body is provided)
+  if (body.length > 0 && !reqOptions.hasOwnProperty('Content-Length')) {
+    reqOptions.headers['content-length'] = Buffer.byteLength(body, 'utf8');
+  }
+
+  // Add authorization headers
+  if (options.username && options.password) {
+    auth = 'Basic ' + new Buffer(options.username + ':' + options.password).toString('base64');
+    options.headers.authorization = auth;
+  }
+
+
+  function reqTimeoutHandler(req) {
+    var err = new Error('ETIMEDOUT, Operation timed out via reqTimeoutHandler');
+    err.errno = constants.ETIMEDOUT;
+    err.code = 'ETIMEDOUT';
+
+    try {
+      req.socket.destroy(err);
+    }
+    catch (e) {}
+  }
+
+  function setReqTimeout(req, timeout) {
+    // TODO: Requires a hack to work on freebsd.
+    var timeoutId = setTimeout(reqTimeoutHandler.bind(null, req), timeout);
+
+    req.on('response', clearTimeout.bind(null, timeoutId));
+    req.on('continue', clearTimeout.bind(null, timeoutId));
+    req.on('error', clearTimeout.bind(null, timeoutId));
+  }
+
+  /* TODO: cache reqOptions.agent */
+  if (customAgent) {
+    if (ssl) {
+      agent = new https.Agent(reqOptions);
+    }
+    else {
+      agent = new http.Agent(reqOptions);
+    }
+
+    reqOptions.agent = agent;
+  }
+
+  async.waterfall([
+    function preRequestHook(callback) {
+      if (!options.hooks.hasOwnProperty('pre_request')) {
+        callback(null, reqOptions);
+        return;
+      }
+
+      // Each hooks gets passed in request options and must pass
+      // (err, modifiedRequestOptions) to its callback
+      options.hooks.pre_request(reqOptions, callback);
+    },
+
+    function performRequest(reqOptions, callback) {
+      // Perform the request
+      try {
+        req = reqFunc(reqOptions);
+        setReqTimeout(req, options.timeout);
+      }
+      catch (err) {
+        callback(err);
+        return;
+      }
+
+      req.on('error', callback);
+      req.on('response', function(res) {
+        var data = '', statusCode, err = null;
+
+        res.setEncoding('utf8');
+
+        res.on('data', function(chunk) {
+          data += chunk;
+        });
+
+        if (!exports.checkStatusCodes(res.statusCode, options.expected_status_codes)) {
+          err = new UnexpectedStatusCodeError(options.expected_status_codes, res.statusCode);
+          err.statusCode = res.statusCode;
+
+          if (!options.return_response) {
+            res.removeAllListeners('data');
+            callback(err);
+            return;
+          }
+        }
+
+        res.on('end', function() {
+          var result = {};
+
+          if (options.parse_json && data.length > 0) {
+            try {
+              data = JSON.parse(data);
+            }
+            catch (err) {
+              err.originalData = data;
+              callback(err);
+              return;
+            }
+          }
+
+          result.headers = res.headers;
+          result.statusCode = res.statusCode;
+          result.body = data;
+
+          if (err && options.return_response) {
+            err.response = result;
+          }
+
+          callback(err, result);
+        });
+      });
+
+      req.end(body);
+    }], callback);
+}
+
+
+/** request function */
+exports.request = request;

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/uuid.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/lib/uuid.js
@@ -1,0 +1,617 @@
+/*
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var ValidationFailureError = require('./errors').ValidationFailureError;
+
+
+
+/**
+ * @constructor
+ * arbitrary unsigned integer.  I haven't taken pains to make it time or space efficient. I just focused on getting
+ * the operations right.
+ * todo: operations could be optimized to be more space-efficient.
+ * @param {int} sz number of bytes.
+ * @param {int} val initial value of this Uint. Mind your mannars.
+ */
+function Uint(sz, val) {
+  val = val || 0;
+  if (sz < 1) {
+    throw new Error('Ints must be at least one byte');
+  }
+  this.sz = sz;
+  this.buf = new Buffer(sz);
+
+  // if val is > 32 bits, we'll be doing a disservice by performing bitwise operations on it.  Use successive
+  // subtraction to determine which bits are asserted.
+  var cur = 0,
+      i = 0,
+      pow = 0;
+  for (i = 0; i < this.sz * 8; i++) {
+    pow = Math.pow(2, this.sz * 8 - i - 1);
+    cur <<= 1;
+
+    if (val - pow >= 0) {
+      val -= pow;
+      cur |= 1;
+    }
+
+    // if we've cross a byte boundary, set the byte and initialize for the next one.
+    if ((i - 7) % 8 === 0) {
+      this.buf[Math.floor(i / 8)] = cur;
+      cur = 0;
+    }
+  }
+}
+
+
+/**
+ * @return {string} a hex formatted version of this uint.
+ */
+Uint.prototype.hexValue = function() {
+  var hex = '',
+      i = 0,
+      str = null;
+  for (i = 0; i < this.sz; i++) {
+    str = this.buf[i].toString(16);
+    while (str.length < 2) {
+      str = '0' + str;
+    }
+    hex += str;
+  }
+  return hex;
+};
+
+
+/**
+ * @param {string} sep (optional) optional field used to separate every byte.
+ * @return {string} binary formatted version of this uint.
+ */
+Uint.prototype.binaryValue = function(sep) {
+  sep = sep || '';
+  var bin = '',
+      i = 0,
+      str = null;
+  for (i = 0; i < this.sz; i++) {
+    str = this.buf[i].toString(2);
+    while (str.length < 8) {
+      str = '0' + str;
+    }
+    bin += str + sep;
+  }
+  return bin.trim();
+};
+
+
+/**
+ * shifts zeros into the bits in a buffer.
+ * @param {Buffer} buf the buffer to shift.
+ * @param {int} num number of bits to shift.
+ * @param {boolean} isLeft a shift is either left or right.
+ */
+function shiftBuf(buf, num, isLeft) {
+  if (num === 0) {
+    return;
+  } else {
+    num = num || 1;
+  }
+
+  // break big shifts into a series of little shifts.
+  while (num > 8) {
+    shiftBuf(buf, 8, isLeft);
+    num -= 8;
+  }
+
+  var next = 0,
+      cur = 0,
+      i = 0;
+  for (i = 0; i < buf.length; i++) {
+    if (isLeft) {
+      cur = (buf[buf.length - 1 - i] << num) | next;
+      next = buf[buf.length - 1 - i] >>> (8 - num);
+      buf[buf.length - 1 - i] = cur;
+    } else {
+      cur = (buf[i] >>> num) | next;
+      next = buf[i] << (8 - num);
+      buf[i] = cur;
+    }
+  }
+}
+
+
+/**
+ * shifts zeros in from the left.
+ * @param {int} num number of bits to shift.
+ * @return {Uint} the shifted result.
+ */
+Uint.prototype.shiftLeft = function(num) {
+  var twin = this.clone();
+  shiftBuf(twin.buf, num, true);
+  return twin;
+};
+
+
+/**
+ * shifts zeros in from the right.
+ * @param {int} num number of bits to shift.
+ * @return {Uint} the shifted result.
+ */
+Uint.prototype.shiftRight = function(num) {
+  var twin = this.clone();
+  shiftBuf(twin.buf, num, false);
+  return twin;
+};
+
+
+/**
+ * @return {Number} JS number format of this uint.  Remember, the coach turns into a pumpkin at 2^52.
+ */
+Uint.prototype.intValue = function() {
+  // don't use bit operations on val here, else you lose precision at 32 bits.
+  // this method still craps out after 52 bits, but hey: we're working with IEEE754 floats.
+  var val = 0,
+      i = 0,
+      bite = 0;
+  for (i = 0; i < 8 * this.sz; i++) {
+    bite = this.buf[Math.floor(i / 8)];
+    bite <<= (i % 8);
+    bite &= 0x00ff;
+    bite >>>= 7;
+    if (bite > 0) {
+      val += Math.pow(2, 8 * this.sz - i - 1);
+    }
+  }
+  return val;
+};
+
+
+/**
+ * clone this uint.
+ * @param {int} sz number of bytes to have in the returned uint.
+ * @return {Uint} copy of this.
+ */
+Uint.prototype.clone = function(sz) {
+  sz = sz || this.sz;
+  var uint = new Uint(sz, 0);
+  // make sure to account for smaller and larger dest buffers.
+  this.buf.copy(uint.buf, sz > this.sz ? sz - this.sz : 0, Math.max(this.sz - sz, 0), this.sz);
+  return uint;
+};
+
+
+/**
+ * slice a few bits from this out into a new uint.
+ * @param {int} start bit offset to start at.
+ * @param {int} length number of bits to copy.
+ * @return {Uint} slice of this.
+ */
+Uint.prototype.sliceBits = function(start, length) {
+  var uint = this.shiftLeft(start);
+  uint = uint.shiftRight(this.sz * 8 - length);
+  return uint;
+};
+
+function safeGet(ui, idx) {
+  if (idx < 0 || idx >= ui.sz) {
+    return 0;
+  } else {
+    return ui.buf[idx];
+  }
+}
+
+
+/**
+ * perform a bitwise AND of two uints.
+ * @param {Uint} uint to AND to this.
+ * @return {Uint} return of AND operation.
+ */
+Uint.prototype.and = function(uint) {
+  var twin = this.clone(),
+      i = 0;
+  for (i = 0; i < Math.min(uint.sz, this.sz); i++) {
+    twin.buf[twin.sz - i - 1] &= uint.buf[uint.sz - i - 1];
+  }
+  return twin;
+};
+
+
+/**
+ * perform a bitwise OR or two uints.
+ * @param {Uint} uint to OR to this.
+ * @return {Uint} return of OR operation.
+ */
+Uint.prototype.or = function(uint) {
+  var twin = this.clone(),
+      i = 0;
+  for (i = 0; i < Math.min(uint.sz, this.sz); i++) {
+    twin.buf[twin.sz - i - 1] |= uint.buf[uint.sz - i - 1];
+  }
+  return twin;
+};
+
+
+/**
+ * Check whether a bit is asserted.
+ * @param {Number} bit The bit to check.
+ * @return {bool} Whether the bit is asserted.
+ */
+Uint.prototype.isBitAsserted = function(bit) {
+  if (bit >= this.sz * 8) {
+    return false;
+  } else {
+    return (this.buf[Math.floor(bit / 8)] & (1 << (7 - (bit % 8)))) !== 0;
+  }
+};
+
+
+/**
+ * add two uints.
+ * @param {Uint} uint number to be added.
+ * @return {Uint} result of addition.
+ */
+Uint.prototype.add = function(uint) {
+  var added = new Uint(Math.max(uint.sz, this.sz)),
+      carry = 0,
+      i = 0,
+      val = 0;
+  for (i = 0; i < added.sz; i++) {
+    val = safeGet(this, this.sz - i - 1) + safeGet(uint, uint.sz - i - 1) + carry;
+    if (val > 255) {
+      carry = 1;
+      val -= 256;
+    } else {
+      carry = 0;
+    }
+    added.buf[added.sz - i - 1] = val;
+  }
+  if (carry !== 0) {
+    throw new Error('Overflow. carry wasn\'t zero.');
+  }
+  return added;
+};
+
+
+/**
+ * subtraction. in the case of underflow, it just returns -1.
+ * @param {Uint} uint number to subtract.
+ * @return {Uint} result of subtraction, or -1 if result would be negative.
+ */
+Uint.prototype.subtract = function(uint) {
+  var subtracted = new Uint(Math.max(uint.sz, this.sz)),
+      carry = 0,
+      i = 0,
+      val = 0;
+
+  for (i = 0; i < subtracted.sz; i++) {
+    val = safeGet(this, this.sz - i - 1) - safeGet(uint, uint.sz - i - 1) - carry;
+    if (val < 0) {
+      carry = 1;
+      val += 256;
+    } else {
+      carry = 0;
+    }
+    subtracted.buf[subtracted.sz - i - 1] = val;
+  }
+  if (carry !== 0) {
+    return -1;
+  } else {
+    return subtracted;
+  }
+};
+
+
+/**
+ * Divide this value by another.
+ * @param {Uint} uint The number to divide by.
+ * @return {Uint} The resulting value.
+ */
+Uint.prototype.divideBy = function(uint) {
+  var sigbits = uint.sz * 8,
+      shifter = uint.clone(),
+      one = new Uint(uint.sz, 1),
+      zero = new Uint(uint.sz, 0),
+      res = new Uint(uint.sz, 0),
+      accum, diff, i;
+
+  while (!shifter.isBitAsserted(0)) {
+    shifter = shifter.shiftLeft(1);
+    sigbits -= 1;
+  }
+
+  accum = this.sliceBits(0, sigbits);
+
+  for (i = 0; i < uint.sz * 8 - sigbits + 1; i += 1) {
+    diff = accum.clone().subtract(uint);
+    if (diff === -1) {
+      res = res.shiftLeft(1).add(zero);
+      accum = accum.shiftLeft(1).add(this.isBitAsserted(sigbits + i) ? one : zero);
+    } else {
+      res = res.shiftLeft(1).add(one);
+      accum = diff.shiftLeft(1).add(this.isBitAsserted(sigbits + i) ? one : zero);
+    }
+  }
+
+  return res;
+};
+
+
+/** an unsigned integer constructor */
+exports.Uint = Uint;
+
+
+/**
+ * returns a randon unint
+ * @param {int} sz number of bytes to use.
+ * @return {Uint} a random unsigned integer.
+ */
+Uint.random = function(sz) {
+  var uint = new Uint(sz, 0),
+      i = 0;
+  for (i = 0; i < sz; i++) {
+    uint.buf[i] = (Math.round(Math.random() * 10000)) % 256;
+  }
+  return uint;
+};
+
+// millis at 00:00:00.000 15 Oct 1582.
+var START_EPOCH = -12219292800000;
+
+var versionMask = new Uint(2, 4096); // 0x1000.
+
+// we use a variant code of 0b10 in accordance with RFC 4122
+var variantCode = new Uint(1, 0x80);
+
+// we use the least significant 14 bits of clock
+var clock = Uint.random(2);
+
+var node = Uint.random(6);
+var lastNanos = 0;
+var lastNanoBuf = new Uint(8, 0);
+var lastTs = 0;
+
+// compute the nanosecond period portion to be used with a time uuid.  detect when the same period is used and add
+// a small offset.
+function nanos(ts) {
+  // if we're going back in time, reset lastNanos. reset the clock too to ensure that different uuids get generated.
+  if (ts < lastTs) {
+    clock = Uint.random(2);
+    lastNanos = 0;
+    lastNanoBuf = new Uint(8, 0);
+  }
+  var nanosSince = (ts - START_EPOCH);
+  if (nanosSince > lastNanos) {
+    // time step has changed. we can reset.
+    lastNanos = nanosSince;
+    lastNanoBuf = new Uint(8, 0);
+    // multiply nanosSince by 10000. converting to an int here would lose precistion, so use the shift and add method.
+    // fwiw, the shifts are derived from the powers of 2 that sum to 10000.
+    [4, 8, 9, 10, 13].forEach(function(shift) {
+      lastNanoBuf = lastNanoBuf.add(new Uint(8, nanosSince).shiftLeft(shift));
+    });
+  } else {
+    // increment by 1 so that a different timestamp is used.
+    lastNanoBuf = lastNanoBuf.add(new Uint(1, 1));
+  }
+  lastTs = ts;
+  return lastNanoBuf;
+}
+
+
+
+/** @constructor creates an empty uuid */
+function UUID() {
+  // does nothing.
+}
+
+
+/**
+ * creates a time UUID based on the current timestamp.
+ * @param {Number} ts timestamp to base UUID from.
+ * @return {UUID} a uuid based on the current time.
+ */
+function uuidFromTimestamp(ts) {
+  ts = ts || Date.now();
+  var uuid = new UUID(),
+      // pro-tip: don't be calling intValue() in time, you'll lose precision!
+      time = nanos(ts);
+  uuid.timeLo = time.sliceBits(32, 32).clone(4); // 4 bytes
+  uuid.timeMid = time.sliceBits(16, 16).clone(2); // 2 bytes
+  uuid.timeHiAndVersion = time.sliceBits(0, 16).clone(2).or(versionMask); // 2 bytes
+  uuid.clockSeqHiAndReserved = clock.sliceBits(2, 6).clone(1).or(variantCode); // 1 byte
+  uuid.clockSeqLo = clock.sliceBits(8, 8).clone(1); // 1 byte
+  uuid.nodeId = node.clone(6); // 6 bytes
+  return uuid;
+}
+
+
+/**
+ * For a given timestamp generate a UUID that Cassandra will consider to be the
+ * 'lowest' possible for that timestamp. This is useful on the low end of
+ * inclusive range queries.
+ * @param {Number} ts Timestamp to create the UUID from.
+ * @return {UUID} A UUID based on the specified time.
+ */
+function lowUUIDFromTimestamp(ts) {
+  var uuid = uuidFromTimestamp(ts);
+  uuid.clockSeqHiAndReserved = variantCode.clone(1);
+  uuid.clockSeqLo = new Uint(1, 0);
+  uuid.nodeId = new Uint(6, 0);
+  return uuid;
+}
+
+
+/**
+ * For a given timestamp generate a UUID that Cassandra will consider to be the
+ * 'highest' possible for that timestamp. This is useful on the high end of
+ * inclusive range queries.
+ * @param {Number} ts Timestamp to create the UUID from.
+ * @return {UUID} A UUID based on the specified time.
+ */
+function highUUIDFromTimestamp(ts) {
+  var uuid = uuidFromTimestamp(ts),
+      maxedLowClock = new Uint(1, 0x3F);
+  uuid.clockSeqHiAndReserved = maxedLowClock.or(variantCode);
+  uuid.clockSeqLo = new Uint(1, 0xFF);
+  uuid.nodeId = new Uint(6, 0xFFFFFFFFFFFF);
+  return uuid;
+}
+
+
+/**
+ * creates a time UUID from a 16-byte buffer.
+ * @param {Buffer} buffer 16 bytes of data.
+ * @return {UUID} a uuid generated from the buffer.
+ */
+function uuidFromBuffer(buffer) {
+  var uuid = new UUID(),
+      i = 0;
+
+  if (!Buffer.isBuffer(buffer)) {
+    // Already a buffer
+    return buffer;
+  }
+
+  // 0xFFFFFFFF00000000 time_low
+  uuid.timeLo = new Uint(4, 0);
+  for (i = 0; i < 4; i++) {
+    uuid.timeLo = uuid.timeLo.shiftLeft(8).or(new Uint(1, buffer[i]));
+  }
+
+  // 0x00000000FFFF0000 time_mid
+  uuid.timeMid = new Uint(2, 0);
+  for (i = 0; i < 2; i++) {
+    uuid.timeMid = uuid.timeMid.shiftLeft(8).or(new Uint(1, buffer[i + 4]));
+  }
+
+  // 0x000000000000F000 version
+  // 0x0000000000000FFF time_hi
+  uuid.timeHiAndVersion = new Uint(2, 0);
+  for (i = 0; i < 2; i++) {
+    uuid.timeHiAndVersion = uuid.timeHiAndVersion.shiftLeft(8).or(new Uint(1, buffer[i + 6]));
+  }
+
+  // ls long
+  // 0xC000000000000000 variant
+  // 0x3FFF000000000000 clock_seq
+  uuid.clockSeqHiAndReserved = new Uint(1, buffer[8]);
+  uuid.clockSeqLo = new Uint(1, buffer[9]);
+
+  // 0x0000FFFFFFFFFFFF node
+  uuid.nodeId = new Uint(6, 0);
+  for (i = 0; i < 6; i++) {
+    uuid.nodeId = uuid.nodeId.shiftLeft(8).or(new Uint(1, buffer[i + 10]));
+  }
+  return uuid;
+}
+
+
+/**
+ * Creates a time UUID from a UUID string
+ * @param {String} str The UUID string.
+ * @return {UUID} a UUID generated from the string.
+ */
+function uuidFromString(str) {
+  var uuid = new UUID(),
+      timeLoStr = str.slice(0, 8),
+      timeMidStr = str.slice(9, 13),
+      timeHiAndVersionStr = str.slice(14, 18),
+      clockSeqHiAndReservedStr = str.slice(19, 21),
+      clockSeqLoStr = str.slice(21, 23),
+      nodeIdStr = str.slice(24, 36);
+
+  uuid.timeLo = new Uint(4, parseInt(timeLoStr, 16));
+  uuid.timeMid = new Uint(2, parseInt(timeMidStr, 16));
+  uuid.timeHiAndVersion = new Uint(2, parseInt(timeHiAndVersionStr, 16));
+  uuid.clockSeqHiAndReserved = new Uint(1, parseInt(clockSeqHiAndReservedStr, 16));
+  uuid.clockSeqLo = new Uint(1, parseInt(clockSeqLoStr, 16));
+  uuid.nodeId = new Uint(6, parseInt(nodeIdStr, 16));
+
+  return uuid;
+}
+
+
+/**
+ * Attempt to validate a version 1 UUID string going to Cassandra.
+ * @param {String} str A UUID string to attempt to validate.
+ * @throws {ValidationFailureError} A validation error.
+ */
+function validateUUIDString(str) {
+  if (!str.match(/^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/)) {
+    throw new ValidationFailureError('Invalid UUID');
+  } else if ((parseInt(str.charAt(19), 16) & 12) !== 8) {
+    throw new ValidationFailureError('Unsupported UUID variant');
+  } else if (str.charAt(14) !== '1') {
+    throw new ValidationFailureError('UUID is not version 1');
+  }
+}
+
+
+/**
+ * <time low> - <time mid> - <time high and version> - <var seq> - <node>.
+ * @return {String} standard UUID formatted string.
+ */
+UUID.prototype.toString = function() {
+  return this.timeLo.hexValue() + '-' +
+         this.timeMid.hexValue() + '-' +
+         this.timeHiAndVersion.hexValue() + '-' +
+         this.clockSeqHiAndReserved.hexValue() + this.clockSeqLo.hexValue() + '-' +
+         this.nodeId.hexValue();
+};
+
+
+/**
+ * Retrieve the timestamp of a uuid.
+ * @return {Number} The timestamp in milliseconds.
+ */
+UUID.prototype.getTimestamp = function() {
+  var timeInNs = new Uint(8, 0), timeInMs;
+
+  timeInNs = timeInNs.or(this.timeHiAndVersion.clone(2).and(new Uint(8, 4095)));
+  timeInNs = timeInNs.shiftLeft(16).or(this.timeMid.clone(2));
+  timeInNs = timeInNs.shiftLeft(32).or(this.timeLo.clone(4));
+
+  timeInMs = timeInNs.divideBy(new Uint(8, 10000));
+
+  return timeInMs.intValue() + START_EPOCH;
+};
+
+
+/** UUID class. */
+exports.UUID = UUID;
+
+
+/** UUID constuctor */
+exports.uuidFromTimestamp = uuidFromTimestamp;
+
+
+/** Generate a low selector uuid */
+exports.lowUUIDFromTimestamp = lowUUIDFromTimestamp;
+
+
+/** Generate a high selector uuid */
+exports.highUUIDFromTimestamp = highUUIDFromTimestamp;
+
+
+/** Attempt to validate a UUID string */
+exports.validateUUIDString = validateUUIDString;
+
+
+/** creates a uuid from a byte buffer */
+exports.uuidFromBuffer = uuidFromBuffer;
+
+
+/** creates a uuid from a uuid string */
+exports.uuidFromString = uuidFromString;

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/package.json
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "rackspace-shared-utils",
+  "author": {
+    "name": "Rackspace US, Inc."
+  },
+  "contributors": [
+    {
+      "name": "Tomaz Muraus",
+      "email": "tomaz.muraus@rackspace.com"
+    },
+    {
+      "name": "Russell Haering",
+      "email": "russell.haering@rackspace.com"
+    },
+    {
+      "name": "Paul Querna",
+      "email": "pquerna@apache.org"
+    },
+    {
+      "name": "Dan Di Spaltro",
+      "email": "daniel.dispaltro@rackspace.com"
+    }
+  ],
+  "version": "0.1.1",
+  "homepage": "https://github.com/racker/node-rackspace-shared-utils",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/racker/node-rackspace-shared-utils.git"
+  },
+  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "dependencies": {
+    "async": "0.1.18",
+    "sprintf": "0.1.1"
+  },
+  "devDependencies": {
+    "jshint": "0.5.9",
+    "whiskey": "0.6.9",
+    "express": "2.5.9"
+  },
+  "scripts": {
+    "lint": "./scripts/lint.sh",
+    "test": "./scripts/tests.sh"
+  },
+  "licenses": [
+    {
+      "type": "Apache",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ],
+  "readme": "# Rackspace Utility Functions\n\nShared Rackspace Node.js utility modules and functions.\n\n# Build status\n\n[![Build Status](https://secure.travis-ci.org/racker/node-rackspace-shared-utils.png)](http://travis-ci.org/racker/node-rackspace-shared-utils)\n\n\n# License\n\nThis library is distributed under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).\n",
+  "readmeFilename": "README.md",
+  "description": "Shared Rackspace Node.js utility modules and functions.",
+  "bugs": {
+    "url": "https://github.com/racker/node-rackspace-shared-utils/issues"
+  },
+  "_id": "rackspace-shared-utils@0.1.1",
+  "_shasum": "e2a25008af1e36620f4874587a74402097413337",
+  "_from": "rackspace-shared-utils@0.1.1",
+  "_resolved": "https://registry.npmjs.org/rackspace-shared-utils/-/rackspace-shared-utils-0.1.1.tgz"
+}

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/scripts/lint.sh
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./node_modules/.bin/jshint $(find ./lib -type f -name "*.js") --config jshint.json

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/scripts/tests.sh
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/scripts/tests.sh
@@ -1,0 +1,8 @@
+if [ ! $TEST_FILES ]; then
+  TEST_FILES=$(find tests/ -type f -name "test-*.js" -print0 | tr "\0" " " | sed '$s/.$//')
+fi
+
+NODE_PATH=lib node_modules/whiskey/bin/whiskey \
+  --tests "${TEST_FILES}" \
+  --custom-assert-module tests/assert.js \
+  --real-time --sequential

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/assert.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/assert.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+
+var sprintf = require('sprintf').sprintf;
+var async = require('async');
+
+// verifies that expected fields are present on a metrics object.
+function hasProperties(obj, expectedProperties, assert) {
+  expectedProperties.forEach(function(field) {
+    assert.ok(obj.hasOwnProperty(field), 'expected field: ' + field + ' not present');
+  });
+}
+
+
+function isWithinRange(actual, expected, allowedDeviation, assert) {
+  var min = (expected - 2 * allowedDeviation);
+  var max = (expected + 2 * allowedDeviation);
+  var isGreaterThanMin = actual >= min;
+  var isLessThanMax = actual <= max;
+  assert.ok(isGreaterThanMin && isLessThanMax, sprintf('!(%s <= %s <= %s)',
+                                                       min, actual, max));
+}
+
+
+function looseCompare(good, suspect, ignoredKeys) {
+  ignoredKeys = ignoredKeys || [];
+  var key;
+
+  for (key in good) {
+    if (ignoredKeys.indexOf(key) !== -1) {
+      continue;
+    }
+
+    assert.deepEqual(good[key], suspect[key]);
+  }
+}
+
+exports.hasProperties = hasProperties;
+exports.isWithinRange = isWithinRange;
+exports.looseCompare = looseCompare;

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-instruments.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-instruments.js
@@ -1,0 +1,231 @@
+var instruments = require('../lib/instruments');
+
+var expectedProperties = ('ops_count rate_1m rate_5m rate_15m ' +
+    'mean_rate min max mean_time std_dev pct_1 pct_25 ' +
+    'pct_75 pct_99 active errors err_rate_1m err_rate_5m ' +
+    'err_rate_15m err_mean_rate').split(' ');
+
+exports['test_clean_shutdown'] = function(test, assert) {
+  var seconds = 2;
+  var perSecond = 100;
+  var sleepTime = 1000 / perSecond;
+  var iterations = seconds * perSecond;
+  var curIt = 0;
+  var interval = setInterval(function() {
+    instruments.measureWork('foo', 5);
+    instruments.measureWork('bar', 10);
+    instruments.measureWork('baz', 20);
+    curIt += 1;
+    if (curIt >= iterations) {
+      clearInterval(interval);
+      instruments.releaseWork('foo');
+      instruments.releaseWork('bar');
+      instruments.releaseWork('baz');
+
+      test.finish();
+    }
+
+  }, sleepTime);
+};
+
+
+exports['test_update_rates'] = function(test, assert) {
+  var seconds = 2;
+  var updatesPerSecond = 100;
+  var sleepTime = 1000 / updatesPerSecond;
+  var iterations = seconds * updatesPerSecond;
+  var curIt = 0;
+  var interval = null;
+  var duration = 10;
+  function measure() {
+    instruments.measureWork('foo2', duration);
+    curIt += 1;
+    if (!interval) {
+      interval = setInterval(measure, sleepTime);
+    } else if (curIt >= iterations) {
+      clearInterval(interval);
+      assert.ok(true);
+      var met = instruments.getWorkMetric('foo2');
+      instruments.releaseWork('foo2');
+      assert.hasProperties(met, expectedProperties, assert);
+      assert.strictEqual(iterations, met.ops_count);
+      assert.isWithinRange(met.mean_rate, updatesPerSecond, 6, assert);
+      assert.strictEqual(duration, met.min);
+      assert.strictEqual(duration, met.max);
+      assert.strictEqual(duration, met.mean_time);
+      assert.strictEqual(0, met.std_dev);
+
+      test.finish();
+    }
+  }
+  measure();
+};
+
+
+exports['test_err_rates'] = function(test, assert) {
+  var seconds = 2;
+  var updatesPerSecond = 100;
+  var sleepTime = 1000 / updatesPerSecond;
+  var iterations = seconds * updatesPerSecond;
+  var curIt = 0;
+  var work = new instruments.Work('error_rates');
+  work.start();
+  var interval = setInterval(function() {
+    work.stop(true);
+    curIt += 1;
+    if (curIt == iterations) {
+      clearInterval(interval);
+      var met = instruments.getWorkMetric('error_rates');
+      instruments.releaseWork('error_rates');
+      assert.hasProperties(met, expectedProperties, assert);
+      assert.isWithinRange(met.err_mean_rate, updatesPerSecond, 6, assert);
+      // can't test the specific minute rates because they only get updated
+      // after 5 secs.
+      test.finish();
+    } else {
+      work = new instruments.Work('error_rates');
+      work.start();
+    }
+  }, sleepTime);
+};
+
+
+exports['test_get_all_metrics'] = function(test, assert) {
+  instruments.measureWork('one', 20);
+  instruments.measureWork('one', 40);
+  instruments.measureWork('two', 60);
+  var all_metrics = instruments.getWorkMetrics().reduce(function(hash, metric) {
+    hash[metric.label] = metric;
+    return hash;
+  }, {});
+  instruments.releaseWork('one');
+  instruments.releaseWork('two');
+  assert.hasProperties(all_metrics.one, expectedProperties, assert);
+  assert.hasProperties(all_metrics.two, expectedProperties, assert);
+  assert.strictEqual(all_metrics.one.ops_count, 2);
+  assert.strictEqual(all_metrics.two.ops_count, 1);
+
+  test.finish();
+};
+
+
+exports['test_distributions'] = function(test, assert) {
+  var data = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+              1, 1, 1, 1, 1,
+              100];
+  for (var i = 0; i < data.length; i++) {
+    instruments.measureWork('test.distributions', data[i]);
+  }
+
+  var met = instruments.getWorkMetric('test.distributions');
+  instruments.releaseWork('test.distributions');
+  assert.hasProperties(met, expectedProperties, assert);
+  assert.strictEqual(data.length, met.ops_count);
+  assert.strictEqual(1, met.min);
+  assert.strictEqual(100, met.max);
+
+  // get it on. verify mean and stddev
+  var sum = function(x, y) { return x + y; };
+  var mean = data.reduce(sum) / data.length;
+  var deviations = data.map(function(x) { return x - mean;});
+  var stddev = Math.sqrt(deviations.map(
+      function(x) {return x * x}).reduce(sum) / (data.length - 1));
+  assert.strictEqual(mean, met.mean_time);
+  assert.strictEqual(stddev, met.std_dev);
+
+  test.finish();
+};
+
+
+exports['test_active_counters'] = function(test, assert) {
+  var i, work;
+  var count = 10;
+  var workers = [];
+  var assertions = [];
+
+  for (i = 0; i < count; i++) {
+    work = new instruments.Work('active_counters');
+    work.start();
+    workers.push(work);
+  }
+  assertions.push(function(met) {
+    return function() {
+      assert.hasProperties(met, expectedProperties, assert);
+      assert.strictEqual(met.active, count);
+    };
+  }(instruments.getWorkMetric('active_counters')));
+
+  for (i = 0; i < count; i++) {
+    work = workers.pop();
+    work.stop();
+    assertions.push(function(met, index) {
+      return function() {
+        assert.hasProperties(met, expectedProperties, assert);
+        assert.strictEqual(met.active, count - index - 1);
+      };
+    }(instruments.getWorkMetric('active_counters'), i));
+  }
+
+  instruments.releaseWork('active_counters');
+
+  // test assertions here.
+  assert.strictEqual(assertions.length, 11);
+  for (var i = 0; i < assertions.length; i++) {
+    assertions[i]();
+  }
+
+  test.finish();
+};
+
+
+exports['test_events'] = function(test, assert) {
+  var i, metrics;
+
+  for (i = 0; i < 10; i++) {
+    instruments.recordEvent('foo');
+  }
+
+  // Rates don't populate until 5 seconds, we overwrite the mean because
+  // it changes depending on timing
+  metrics = instruments.getEventMetrics();
+  metrics[0].rate_mean = 0;
+
+  assert.deepEqual(metrics, [
+    {
+      label: 'foo',
+      count: 10,
+      rate_1m: 0,
+      rate_5m: 0,
+      rate_15m: 0,
+      rate_mean: 0
+    }
+  ]);
+
+  instruments.releaseEvent('foo');
+  test.finish();
+};
+
+
+exports['test_DummyWork'] = function(test, assert) {
+  var work = new instruments.DummyWork('test_disabled'),
+      key, value, count = 0;
+
+  work.start();
+  setTimeout(function() {
+    var met;
+
+    work.stop(true);
+
+    met = instruments.getWorkMetric('test_disabled');
+    for (key in met) {
+      if (met.hasOwnProperty(key) && ['label', 'serializerType'].indexOf(key) === -1) {
+        count++;
+        value = met[key];
+        assert.equal(value, 0);
+      }
+    }
+
+    assert.equal(count, Object.keys(met).length - 1);
+    test.finish();
+  }, 100);
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-flow-control.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-flow-control.js
@@ -1,0 +1,93 @@
+var async = require('async');
+
+var flowCtrl = require('../lib/flow_control');
+
+
+exports['test_retryOnError_success'] = function(test, assert) {
+  var options = { 'max_retries': 2 }, payload = {};
+
+  function run(callback) {
+    callback();
+  }
+
+  flowCtrl.retryOnError(run, null, null, null, function(err) {
+    assert.ifError(err);
+    test.finish();
+  });
+};
+
+
+exports['test_retryOnError_retry_success'] = function(test, assert) {
+  var args = [1], i = 0, options = { 'max_retries': 3 };
+
+  function run(failures, callback) {
+    i++;
+    if (i <= failures) {
+      callback(new Error('failure'));
+      return;
+    }
+    callback();
+  }
+
+  flowCtrl.retryOnError(run, null, args, options, function(err) {
+    assert.ifError(err);
+    assert.equal(i, 2);
+    test.finish();
+  });
+};
+
+
+exports['test_retryOnError_retry_failure'] = function(test, assert) {
+  var args = [2], i = 0, options = { 'max_retries': 1 };
+
+  function run(failures, callback) {
+    i++;
+    if (i <= failures) {
+      callback(new Error('failure'));
+      return;
+    }
+    callback();
+  }
+
+  flowCtrl.retryOnError(run, null, args, options, function(err) {
+    assert.ok(err);
+    assert.equal(i, 2);
+    test.finish();
+  });
+};
+
+
+exports['test_wrapCallback'] = function(test, assert) {
+  function callbackError(callback) {
+    callback(new Error());
+  }
+
+  function callbackSuccess(callback) {
+    callback(null, 1, 2);
+  }
+
+  async.series([
+    function testError(callback) {
+      callbackError(flowCtrl.wrapCallback(function() {
+        assert.ok(arguments.length === 1);
+        callback();
+      }, ['foo', 'bar'], false));
+    },
+
+    function testSuccessOne(callback) {
+      callbackSuccess(flowCtrl.wrapCallback(function() {
+        assert.ok(arguments.length === 3);
+        assert.deepEqual(Array.prototype.slice.call(arguments), [null, 'foo', 'bar']);
+        callback();
+      }, ['foo', 'bar'], false));
+    },
+
+    function testSuccessOne(callback) {
+      callbackSuccess(flowCtrl.wrapCallback(function() {
+        assert.ok(arguments.length === 5);
+        assert.deepEqual(Array.prototype.slice.call(arguments), [null, 'foo', 'bar', 1, 2]);
+        callback();
+      }, ['foo', 'bar'], true));
+    }
+  ], test.finish);
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-misc.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-misc.js
@@ -1,0 +1,89 @@
+var misc = require('../lib/misc');
+
+
+exports['test_object_merge'] = function(test, assert) {
+  var a = {foo: 1};
+  var b = {bar: 2};
+  var c = {foo: 1, bar: 2};
+  var out = misc.merge(a, b);
+  assert.deepEqual(c, out);
+  out = misc.merge(out, {});
+  assert.deepEqual(c, out);
+  out = misc.merge({}, out);
+  assert.deepEqual(c, out);
+
+  test.finish();
+};
+
+
+exports['test_empty_object_merge'] = function(test, assert) {
+  var a = {};
+  var b = {};
+  var c = {};
+  var out = misc.merge(a, b);
+  assert.deepEqual(c, out);
+
+  test.finish();
+};
+
+exports['test_indent'] = function(test, assert) {
+  assert.equal(misc.indent('test', 1, ' '), ' test');
+  assert.equal(misc.indent('test', 2, ' '), '  test');
+  assert.equal(misc.indent('test', 2, '  '), '    test');
+  assert.equal(misc.indent(' test', 2, '  '), '     test');
+  test.finish();
+};
+
+
+exports['test_getValues'] = function(test, assert) {
+  var values = [
+    { 'obj': {'a': 'b', 'b': 'c', 'd': 'd'},
+      'value': ['b', 'c', 'd']
+    },
+    { 'obj': {'a': 'b', 'b': 'c', 'd': 1, 'f': 1},
+      'value': ['b', 'c', 1, 1]
+    }
+  ], key, obj, i, len;
+
+  for (i = 0, len = values.length; i < len; i++) {
+    obj = values[i];
+    assert.deepEqual(misc.getValues(obj.obj), obj.value);
+  }
+
+  assert.equal(i, 2);
+  test.finish();
+};
+
+
+exports['test_getRandomAddress'] = function(test, assert) {
+  var addresses = ['1.2.3.4:1111', '1.2.3.5:2222', '1.2.3.5:5555'],
+      ports = ['1111', '2222', '5555'],
+      address = misc.getRandomAddress(addresses);
+
+  assert.equal(address.length, 2);
+  assert.ok(ports.indexOf(address[1]) !== -1);
+  assert.ok(addresses.indexOf(address.join(':')) !== -1);
+  test.finish();
+};
+
+
+exports['test_splitAddress'] = function(test, assert) {
+  var addresses = ['127.0.0.1:5000', '55.55.55.55:12345',
+                   '70:cd:60:ff:fe:ae:0a:88:8888', '70:cd:60:ff:fe:ae:0a:88:5555'],
+      expected = [['127.0.0.1', '5000'], ['55.55.55.55', '12345'],
+                  ['70:cd:60:ff:fe:ae:0a:88', '8888'], ['70:cd:60:ff:fe:ae:0a:88', '5555']],
+      i;
+
+  for (i = 0; i < addresses.length; i++) {
+    assert.deepEqual(misc.splitAddress(addresses[i]), expected[i]);
+  }
+
+  test.finish();
+};
+
+exports['test_toRfc3339Date'] = function(test, assert) {
+  assert.equal(misc.toRfc3339Date(new Date(Date.UTC(2012, 9, 24, 10, 10, 55, 22))), '2012-10-24T10:10:55Z');
+  assert.equal(misc.toRfc3339Date(new Date(Date.UTC(2012, 6, 5, 10, 9, 55, 22))), '2012-07-05T10:09:55Z');
+  test.finish();
+};
+

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-request.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-util-request.js
@@ -1,0 +1,182 @@
+var constants = require('constants');
+
+var async = require('async');
+var express = require('express');
+
+var request = require('../lib/request');
+var UnexpectedStatusCodeError = require('../lib/errors').UnexpectedStatusCodeError;
+
+function getTestHttpServer(port, ip, callback) {
+  ip = ip || '127.0.0.1';
+
+  var server = express.createServer();
+  server.listen(port, ip, callback.bind(server, server));
+}
+
+exports['test_request'] = function(test, assert) {
+  var port = 7956, url = 'http://127.0.0.1:' + port,
+      server = null, options;
+
+  async.series([
+    function startTestServer(callback) {
+      getTestHttpServer(port, '127.0.0.1', function(server_) {
+        function reqHandlerError(req, res) {
+          res.writeHead(500, {});
+          res.end('');
+        }
+
+        function reqHandlerBody(req, res) {
+          res.writeHead(200, { 'content-type': 'application/json'});
+          res.end(req.body);
+        }
+
+        function reqHandlerMalformedJson(req, res) {
+          res.writeHead(200, { 'content-type': 'application/json'});
+          res.end("{'foo 1: ");
+        }
+
+        server_.get('/test-url', reqHandlerError);
+        server_.get('/test-url-body', reqHandlerBody);
+        server_.get('/test-url-malformed-json', reqHandlerMalformedJson);
+
+        server = server_;
+        callback();
+      });
+    },
+
+    function testConnRefused(callback) {
+      request.request('http://127.0.0.1:34890', 'GET', null, {}, function onResponse(err, result) {
+        assert.ok(err);
+        assert.equal(err.code, 'ECONNREFUSED');
+        assert.ok(!result);
+        callback();
+      });
+    },
+
+    function testSuccess(callback) {
+      options = {
+        'parse_json': false,
+        'expected_status_codes': [500]
+      };
+
+      request.request(url + '/test-url', 'GET', null, options, function onResponse(err, result) {
+        assert.ifError(err);
+        callback();
+      });
+    },
+
+    function testMalformedJson(callback) {
+      options.parse_json = true;
+      options.expected_status_codes = [200];
+
+      request.request(url + '/test-url-malformed-json', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(err);
+        assert.equal(err.originalData, "{'foo 1: ");
+        assert.equal(err.type, 'unexpected_token');
+        callback();
+      });
+    },
+
+    function testUnexpectedStatusCode1(callback) {
+      options.parse_json = false;
+      options.expected_status_codes = [200];
+
+      request.request(url + '/some-inextensitent-path', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(!response);
+        assert.ok(err && (err instanceof UnexpectedStatusCodeError));
+        assert.ok(err.statusCode, 404);
+        assert.match(err.message, /unexpected status code/i);
+        callback();
+      });
+    },
+
+    function testUnexpectedStatusCode2(callback) {
+      options.parse_json = true;
+      options.expected_status_codes = [200];
+
+      request.request(url + '/test-url', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(!response);
+        assert.ok(err && (err instanceof UnexpectedStatusCodeError));
+        assert.match(err.message, /unexpected status code/i);
+        callback();
+      });
+    },
+
+    function testUnexpectedStatusCodeReturnResponse(callback) {
+      options.parse_json = false;
+      options.expected_status_codes = [200];
+      options.return_response = true;
+
+      request.request(url + '/some-inextensitent-path', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(response);
+        assert.match(response.body, /Cannot GET \/some-inextensitent-path/);
+        assert.ok(err && (err instanceof UnexpectedStatusCodeError));
+        assert.ok(err.statusCode, 404);
+        assert.match(err.message, /unexpected status code/i);
+        callback();
+      });
+    },
+
+    function testReqTimeout(callback) {
+      options.timeout = 500;
+      request.request('http://google.com:8285', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(err);
+        assert.equal(err.errno, constants.ETIMEDOUT);
+        assert.match(err.message, /operation timed out/i);
+        callback();
+      });
+    },
+
+    function tesPreRequestHookDenied(callback) {
+      function hook(reqOptions, callback) {
+        if (reqOptions.host === 'google.com') {
+          callback(new Error('PONIES'));
+        }
+        else {
+          callback(null, reqOptions);
+        }
+      }
+
+      options.hooks = {};
+      options.hooks.pre_request = hook;
+      request.request('http://google.com:8285', 'GET', null, options, function onResponse(err, response) {
+        assert.ok(err);
+        assert.ok(!response);
+        assert.match(err.message, /ponies/i);
+        callback();
+      });
+    },
+
+    function tesPreRequestHookSuccess(callback) {
+      request.request('http://127.0.0.1:34890', 'GET', null, {}, function onResponse(err, result) {
+        assert.ok(err);
+        assert.equal(err.code, 'ECONNREFUSED');
+        assert.ok(!result);
+        callback();
+      });
+    }
+  ],
+
+  function(err) {
+    if (server) {
+      server.close();
+    }
+
+    test.finish();
+  });
+};
+
+
+exports['test_checkStatusCode'] = function(test, assert) {
+  assert.ok(request.checkStatusCodes(200, ['300', '200']));
+  assert.ok(request.checkStatusCodes(200, ['300', 200]));
+  assert.ok(request.checkStatusCodes(200, [/3../, 200]));
+  assert.ok(request.checkStatusCodes(220, [/[23]../]));
+  assert.ok(request.checkStatusCodes(220, [/2[0-9]{2}/]));
+  assert.ok(request.checkStatusCodes(299, [/2[0-9]{2}/]));
+  assert.ok(request.checkStatusCodes(200, [/2[0-9]{2}/]));
+  assert.ok(!request.checkStatusCodes(300, [/2[0-9]{2}/]));
+  assert.ok(request.checkStatusCodes(500, [500]));
+
+  test.finish();
+};

--- a/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-uuid.js
+++ b/node_modules/keystone-client/node_modules/rackspace-shared-utils/tests/test-uuid.js
@@ -1,0 +1,347 @@
+var uint = require('../lib/uuid').Uint;
+var uuidFromTimestamp = require('../lib/uuid').uuidFromTimestamp;
+var uuidFromBuffer = require('../lib/uuid').uuidFromBuffer;
+
+exports['test_zero'] = function(test, assert) {
+  var sizes = [1, 4, 8, 16, 32, 64, 128];
+  sizes.forEach(function(sz) {
+    var x = new uint(sz);
+    assert.strictEqual(x.intValue(), 0);
+  });
+  test.finish();
+};
+
+exports['test_invalid_sizes'] = function(test, assert) {
+  var invalidSizes = [0, -1, -8];
+  invalidSizes.forEach(function(sz) {
+    try {
+      var x = new uint(sz);
+      assert.ok(false, 'you shouldn\'t be able to do that.');
+    } catch (err) {
+      assert.ok(err);
+    }
+  });
+  test.finish();
+};
+
+exports['test_simple_left_shift'] = function(test, assert) {
+  var x = new uint(4, 1);
+  for (var i = 0; i < 32; i++) {
+    assert.strictEqual(Math.pow(2, i), x.intValue());
+    x = x.shiftLeft();
+  }
+
+  x = new uint(4, 1);
+  for (i = 0; i < 16; i++) {
+    assert.strictEqual(Math.pow(2, 2 * i), x.intValue());
+    x = x.shiftLeft(2);
+  }
+  test.finish();
+};
+
+exports['test_simple_right_shift'] = function(test, assert) {
+  var x = new uint(4, 2147483648); // Math.pow(2, 31)
+  for (var i = 0; i < 32; i++) {
+    assert.strictEqual(Math.pow(2, 31 - i), x.intValue());
+    x = x.shiftRight();
+  }
+
+  var x = new uint(4, 2147483648);
+  for (var i = 0; i < 16; i++) {
+    assert.strictEqual(Math.pow(2, 31 - i * 2), x.intValue());
+    x = x.shiftRight(2);
+  }
+  test.finish();
+};
+
+exports['test_complex_left_shift'] = function(test, assert) {
+  var x = new uint(5, 1097363558964);
+  var shiftValues = [
+    1097363558964,
+    1095215490152,
+    1090919352528,
+    1082327077280,
+    1065142526784,
+    1030773425792,
+    962035223808,
+    824558819840,
+    549606011904,
+    1099212023808,
+    1098912419840,
+    1098313211904,
+    1097114796032,
+    1094717964288,
+    1089924300800,
+    1080336973824,
+    1061162319872
+  ];
+  shiftValues.forEach(function(testValue) {
+    assert.strictEqual(testValue, x.intValue());
+    x = x.shiftLeft();
+  });
+
+  x = new uint(5, 1097363558964);
+  for (var i = 0; i < shiftValues.length / 2; i++) {
+    assert.strictEqual(shiftValues[2 * i], x.intValue());
+    x = x.shiftLeft(2);
+  }
+
+  // shift 8 is a whole byte
+  x = new uint(5, 1097363558964);
+  x = x.shiftLeft(8);
+  assert.strictEqual(549606011904, x.intValue());
+
+  test.finish();
+};
+
+exports['test_big_left_shift'] = function(test, assert) {
+  var x = new uint(5, 1097363558964);
+  x = x.shiftLeft(12);
+  assert.strictEqual(1097114796032, x.intValue());
+  test.finish();
+};
+
+exports['test_complex_right_shift'] = function(test, assert) {
+  var x = new uint(5, 1097363558964);
+  var shiftValues = [
+    1097363558964,
+    548681779482,
+    274340889741,
+    137170444870,
+    68585222435,
+    34292611217,
+    17146305608,
+    8573152804,
+    4286576402,
+    2143288201,
+    1071644100,
+    535822050,
+    267911025,
+    133955512,
+    66977756,
+    33488878,
+    16744439
+  ];
+  shiftValues.forEach(function(testValue) {
+    assert.strictEqual(testValue, x.intValue());
+    x = x.shiftRight();
+  });
+
+  x = new uint(5, 1097363558964);
+  for (var i = 0; i < shiftValues.length / 2; i++) {
+    assert.strictEqual(shiftValues[2 * i], x.intValue());
+    x = x.shiftRight(2);
+  }
+
+  // shift 8 is a whole byte
+  x = new uint(5, 1097363558964);
+  x = x.shiftRight(8);
+  assert.strictEqual(4286576402, x.intValue());
+
+  test.finish();
+};
+
+exports['test_big_right_shift'] = function(test, assert) {
+  var x = new uint(5, 1097363558964);
+  x = x.shiftRight(12);
+  assert.strictEqual(267911025, x.intValue());
+  test.finish();
+};
+
+exports['test_clone'] = function(test, assert) {
+  var x = new uint(2, 26046); // 0x65be
+
+  // baseline.
+  assert.strictEqual(x.intValue(), 26046);
+
+  // clone into a smaller destination (grabs least significant portion that fits).
+  var sliceClone = x.clone(1);
+  assert.strictEqual(sliceClone.intValue(), 190);
+  assert.strictEqual(sliceClone.sz, 1);
+
+  // simple clone.
+  var xClone = x.clone();
+  assert.strictEqual(x.intValue(), xClone.intValue());
+  assert.strictEqual(x.sz, xClone.sz);
+
+  var bigXClone = x.clone(5);
+  assert.strictEqual(x.intValue(), bigXClone.intValue());
+  assert.strictEqual(5, bigXClone.sz);
+
+  test.finish();
+};
+
+exports['test_hex_string'] = function(test, assert) {
+  var x = new uint(8, 1097363558964);
+  assert.strictEqual('000000ff7ff71234', x.hexValue());
+  test.finish();
+};
+
+exports['test_slice_bits'] = function(test, assert) {
+  var x = new uint(8, 1097363558964);
+
+  var a = x.sliceBits(8, 8);
+  assert.strictEqual(a.intValue(), 0);
+  assert.strictEqual(a.sz, 8);
+  assert.strictEqual(x.sliceBits(24, 8).intValue(), 255);
+  assert.strictEqual(x.sliceBits(28, 8).intValue(), 247); // 1111-0111 (straddles a byte boundary.
+  assert.strictEqual(x.sliceBits(18, 18).intValue(), 4087); // straddles two byte boundaries at odd places. 0xff7
+
+  var y = new uint(2, 48);
+  assert.strictEqual(y.intValue(), 48);
+  assert.strictEqual(y.sliceBits(0, 16).intValue(), 48);
+
+  y = new uint(8, 13532978640772000);
+  assert.strictEqual(y.intValue(), 13532978640772000);
+  assert.strictEqual(y.sliceBits(0, 16).intValue(), 48);
+
+  test.finish();
+};
+
+exports['test_add'] = function(test, assert) {
+  var a = new uint(2, 255);
+  var b = new uint(2, 1);
+  var c = new uint(2, 100);
+  var d = new uint(1, 100);
+  assert.strictEqual(d.sz, 1);
+
+  assert.strictEqual(a.add(b).intValue(), 256);
+  assert.strictEqual(a.add(a).intValue(), 510);
+  assert.strictEqual(a.add(c).intValue(), 355);
+  assert.strictEqual(a.add(d).intValue(), 355);
+  assert.strictEqual(d.add(a).intValue(), 355);
+  test.finish();
+};
+
+exports['test_subtract'] = function(test, assert) {
+  var one = new uint(1, 1),
+      zero = new uint(1, 0),
+      twofiftyfive = new uint(1, 255),
+      twofiftysix = new uint(2, 256);
+
+  // Subtraction resulting in non-negative numbers returns the correct uuint
+  assert.strictEqual(one.subtract(one).intValue(), 0);
+  assert.strictEqual(one.subtract(zero).intValue(), 1);
+  assert.strictEqual(twofiftysix.subtract(twofiftyfive).intValue(), 1);
+  assert.strictEqual(twofiftysix.subtract(one).intValue(), 255);
+
+  // Subtraction resulting in underflow results in -1
+  assert.strictEqual(one.subtract(twofiftyfive), -1);
+  assert.strictEqual(twofiftyfive.subtract(twofiftysix), -1);
+  test.finish();
+};
+
+exports['test_is_bit_asserted'] = function(test, assert) {
+  var one = new uint(1, 1),
+      zero = new uint(1, 0),
+      twofiftyfive = new uint(1, 255),
+      twofiftysix = new uint(2, 256);
+
+  // Given a uint and an array of indices, make sure only bits at those indices
+  // are asserted
+  function onlyAsserted(value, indices) {
+    var i;
+
+    // We intentionally go too far, these should return false
+    for (i = 0; i < value.sz * 8 + 10; i++) {
+      assert.equal(value.isBitAsserted(i), indices.indexOf(i) !== -1);
+    }
+  }
+
+  onlyAsserted(zero, []);
+  onlyAsserted(one, [7]);
+  onlyAsserted(twofiftyfive, [0, 1, 2, 3, 4, 5, 6, 7]);
+  onlyAsserted(twofiftysix, [7]);
+  test.finish();
+};
+
+exports['test_divide_by'] = function(test, assert) {
+  var twothirty = new uint(1, 230),
+      six = new uint(1, 6),
+      ten = new uint(1, 10),
+      twelve = new uint(1, 12),
+      fourtyeight = new uint(1, 48),
+      fourtynine = new uint(1, 49),
+      eightbytefourtyeight = new uint(8, 48),
+      eightbytetwelve = new uint(8, 12),
+      eightbyteten = new uint(8, 10),
+      largeishnumber = new uint(8, 58880);
+
+  assert.equal(twothirty.divideBy(six).intValue(), 38);
+  assert.equal(fourtyeight.divideBy(twelve).intValue(), 4);
+  assert.equal(eightbytefourtyeight.divideBy(eightbytetwelve).intValue(), 4);
+  assert.equal(fourtynine.divideBy(twelve).intValue(), 4);
+  assert.equal(largeishnumber.divideBy(eightbyteten).intValue(), 5888);
+  test.finish();
+};
+
+exports['test_or'] = function(test, assert) {
+  var a = new uint(2, 196);
+  var b = new uint(2, 170);
+  // test mismatched ORing.
+  var c = new uint(5, 170);
+  assert.strictEqual(a.or(b).intValue(), 238);
+  assert.strictEqual(a.or(c).intValue(), 238);
+  assert.strictEqual(c.or(a).intValue(), 238);
+  test.finish();
+};
+
+exports['test_uuid'] = function(test, assert) {
+  var old = null;
+  for (var i = 0; i < 10; i++) {
+    var cur = uuidFromTimestamp(Date.now());
+    if (old) {
+      assert.ok(old.toString() < cur.toString());
+    }
+    old = cur;
+  }
+  test.finish();
+};
+
+exports['test_uuid_from_buffer'] = function(test, assert) {
+  var buf = new Buffer('\u00ee\u00a1\u006c\u00c0\u00cf\u00bd\u0011\u00e0\u0017' +
+          '\u000a\u00dd\u0026\u0075\u0027\u009e\u0008', 'binary');
+  var uuid = uuidFromBuffer(buf);
+  assert.strictEqual(uuid.toString(), 'eea16cc0-cfbd-11e0-170a-dd2675279e08');
+  test.finish();
+};
+
+exports['test_uuid_backwards_in_time'] = function(test, assert) {
+  var ts = 1314735336316;
+  var uuidTs = uuidFromTimestamp(ts).toString();
+  // this forces the nano tracker in uuid to get set way ahead.
+  var uuidFuture = uuidFromTimestamp(ts + 5000).toString();
+  // we want to verify that the nanos used reflect ts and not ts+5000.
+  var uuidTsSame = uuidFromTimestamp(ts).toString();
+  assert.ok(uuidTs !== uuidFuture); // duh
+  assert.ok(uuidTs !== uuidTsSame); // generated from same TS after going back in time.
+  // but time lo should definitely be the same.
+  // this test would have failed before we started using the back-in-time reset block in UUID.nanos().
+  assert.strictEqual(uuidTs.split('-')[0], uuidTsSame.split('-')[0]);
+  test.finish();
+};
+
+
+exports['test_uuid_forward_reverse'] = function(test, assert) {
+  var testAtYears = [-5, 0, 1, 10, 100];
+
+  // Note: we assume a year is exactly 365 days, this shouldn't matter
+  function testAtYearsInFuture(yearsInFuture) {
+    var ts = (Date.now() + yearsInFuture * 365 * 24 * 60 * 60 * 1000),
+        uuid, i;
+
+    // Generate 100 uuids with each timestamp
+    for (i = 0; i < 100; i++) {
+      uuid = uuidFromTimestamp(ts);
+      assert.strictEqual(uuid.getTimestamp(), ts);
+    }
+  }
+
+  // Test at various points in time
+  testAtYears.forEach(testAtYearsInFuture);
+
+  // Go "back in time" from the latest tested point
+  testAtYearsInFuture(0);
+
+  test.finish();
+};

--- a/node_modules/keystone-client/package.json
+++ b/node_modules/keystone-client/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "keystone-client",
+  "description": "A Node.js client for the OpenStack Keystone Identity service.",
+  "author": {
+    "name": "Rackspace US, Inc."
+  },
+  "contributors": [
+    {
+      "name": "Paul Querna",
+      "email": "pquerna@apache.org"
+    },
+    {
+      "name": "Dan Di Spaltro",
+      "email": "daniel.dispaltro@rackspace.com"
+    },
+    {
+      "name": "Tomaz Muraus",
+      "email": "tomaz.muraus@rackspace.com"
+    }
+  ],
+  "version": "0.3.0",
+  "homepage": "https://github.com/racker/node-keystone-client",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/racker/node-keystone-client.git"
+  },
+  "main": "lib/client.js",
+  "directories": {
+    "lib": "./lib",
+    "examples": "./examples"
+  },
+  "dependencies": {
+    "async": "0.1.18",
+    "sprintf": "0.1.1",
+    "rackspace-shared-utils": "0.1.1"
+  },
+  "devDependencies": {
+    "jshint": "0.5.9",
+    "whiskey": "0.6.9",
+    "express": "2.5.6"
+  },
+  "scripts": {
+    "lint": "./scripts/lint.sh",
+    "test": "./scripts/tests.sh"
+  },
+  "licenses": [
+    {
+      "type": "Apache",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  ],
+  "readme": "# Node.js Keystone Client\n\nA Node.js client for the [OpenStack Keystone Identity service](http://keystone.openstack.org/).\n\n# Build status\n\n[![Build Status](https://secure.travis-ci.org/racker/node-keystone-client.png)](http://travis-ci.org/racker/node-keystone-client)\n\n# License\n\nThis library is distributed under the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).\n",
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://github.com/racker/node-keystone-client/issues"
+  },
+  "_id": "keystone-client@0.3.0",
+  "_from": "keystone-client@^0.3.0"
+}

--- a/node_modules/keystone-client/scripts/lint.sh
+++ b/node_modules/keystone-client/scripts/lint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./node_modules/.bin/jshint $(find ./lib ./tests -type f -name "*.js") --config jshint.json

--- a/node_modules/keystone-client/scripts/tests.sh
+++ b/node_modules/keystone-client/scripts/tests.sh
@@ -1,0 +1,9 @@
+if [ ! $TEST_FILES ]; then
+  TEST_FILES=$(find tests/ -type f -name "test-*.js" -print0 | tr "\0" " " | sed '$s/.$//')
+fi
+
+NODE_PATH=lib node_modules/whiskey/bin/whiskey \
+  --tests "${TEST_FILES}" \
+  --dependencies tests/dependencies.json \
+  --custom-assert-module tests/assert.js \
+  --real-time --sequential

--- a/node_modules/keystone-client/tests/dependencies.json
+++ b/node_modules/keystone-client/tests/dependencies.json
@@ -1,0 +1,12 @@
+{
+  "mock_auth_api": {
+    "cmd": ["dev-bin/mock-auth-api-server"],
+    "cwd": ["__dirname", ".."],
+    "log_file": "test-mock-auth-api-server.log",
+    "wait_for": "socket",
+    "wait_for_options": {
+      "host": "127.0.0.1",
+      "port": 23542
+    }
+  }
+}

--- a/node_modules/keystone-client/tests/mock-auth-server.js
+++ b/node_modules/keystone-client/tests/mock-auth-server.js
@@ -1,0 +1,358 @@
+/**
+ *  Copyright 2012 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var http = require('http');
+var util = require('util');
+
+var express = require('express');
+
+var sprintf = require('sprintf').sprintf;
+
+var misc = require('rackspace-shared-utils/lib/misc');
+
+/**
+ * Maps tokens to external ids.
+ * @type {Object}
+ * @const
+ */
+
+var TOKEN_TO_INFO = {
+  'XXXXXXXXXXZZZZZZZ': ['reachdevsf', '666'],
+  'blahahahbtoken': ['username1', '1111'],
+  'toldmeicouldntcomeoverandplayanymore' : ['yourmom', '6666'],
+  'dev': ['joe', '7777'],
+  'never-cache-this': ['fooooo', '02222']
+};
+
+var USERNAME_TO_TOKEN_MAP = (function() {
+  var k, rv = {};
+  for (k in TOKEN_TO_INFO) {
+    if (TOKEN_TO_INFO.hasOwnProperty(k)) {
+      rv[TOKEN_TO_INFO[k][0]] = k;
+    }
+  }
+  return rv;
+})();
+
+var USERNAME_TO_TENANT_ID_MAP = (function() {
+  var k, rv = {};
+  for (k in TOKEN_TO_INFO) {
+    if (TOKEN_TO_INFO.hasOwnProperty(k)) {
+      rv[TOKEN_TO_INFO[k][0]] = TOKEN_TO_INFO[k][1];
+    }
+  }
+  return rv;
+})();
+
+var TENANT_ID_TO_USERNAME_MAP = (function() {
+  var k, rv = {};
+  for (k in TOKEN_TO_INFO) {
+    if (TOKEN_TO_INFO.hasOwnProperty(k)) {
+      rv[TOKEN_TO_INFO[k][1]] = TOKEN_TO_INFO[k][0];
+    }
+  }
+  return rv;
+})();
+
+function handleRequest_v_1_1(req, res) {
+  var token = req.params.tokenId,
+      type = req.query.type,
+      fail = req.query.fail || false,
+      expiresTs = misc.getUnixTimestamp(), username, expires, statusCode, body;
+
+  expires = new Date();
+  expires.setTime((expiresTs + 100) * 1000);
+  expires = expires.toString();
+  username = TOKEN_TO_INFO[token][1];
+
+  if (fail) {
+    statusCode = 401;
+    body = {};
+  }
+  else {
+    if (!username) {
+      username = "reachdevsf";
+    }
+    statusCode = 200;
+    body = {
+      'token' : {
+        'id' : token,
+        'userId' : username,
+        'userURL' : '/users/' + username,
+        'created' : '2010-11-01T03:32:15-05:00',
+        'expires' : expires }
+    };
+    console.log(body);
+  }
+
+  res.writeHead(statusCode, {'Content-Type': 'application/json'});
+  res.end(JSON.stringify(body));
+}
+
+
+function getToken_v2_0(req, res) {
+  var type = req.query.type,
+      fail = req.query.fail || false,
+      expiresTs = misc.getUnixTimestamp(),
+      username,
+      tenantId,
+      token,
+      expires,
+      statusCode,
+      body,
+      creds,
+      providedToken,
+      reason = 'api was asked to fail';
+
+  expires = new Date();
+  expires.setTime((expiresTs + 100) * 1000);
+  expires = expires.toString();
+
+  if (!req.body.auth) {
+    fail = true;
+    statusCode = 500;
+    reason = 'missing auth in body: ' + JSON.stringify(req.body);
+  }
+  else {
+    creds = req.body.auth;
+
+    if (creds.hasOwnProperty('tenantName')) {
+      tenantId = creds.tenantName;
+      username = TENANT_ID_TO_USERNAME_MAP[tenantId];
+      providedToken = req.body.auth.token.id;
+    }
+    else if (creds.hasOwnProperty('RAX-KSKEY:apiKeyCredentials')) {
+      username = creds['RAX-KSKEY:apiKeyCredentials'].username;
+      providedToken = creds['RAX-KSKEY:apiKeyCredentials'].apiKey;
+      tenantId = USERNAME_TO_TENANT_ID_MAP[username];
+    }
+
+    token = USERNAME_TO_TOKEN_MAP[username];
+
+    if (!token || !tenantId) {
+      fail = true;
+      statusCode = 501;
+      reason = 'missing user in map auth map: ' + username + ' token:' + token + ' tenantId:'+ tenantId;
+    }
+    else if (token !== providedToken) {
+      fail = true;
+      statusCode = 502;
+      reason = 'invalid token';
+    }
+  }
+
+  if (fail) {
+    statusCode = statusCode || 401;
+    body = {'reason': reason};
+  }
+  else {
+    statusCode = 200;
+
+    body = {
+        "access": {
+            "token": {
+                "id": token,
+                "expires": expires,
+                "tenant": {"id": tenantId, "name": tenantId}
+            },
+            "serviceCatalog": [
+                {
+                    "endpoints": [
+                        {
+                            "region": "ORD",
+                            "tenantId": tenantId,
+                            "publicURL": "https://storage101.ord1.clouddrive.com/v1/" + tenantId,
+                            "internalURL": "https://snet-storage101.ord1.clouddrive.com/v1/"+ tenantId
+                        }
+                    ],
+                    "name": "cloudFiles",
+                    "type": "object-store"
+                },
+                {
+                    "endpoints": [
+                        {
+                            "tenantId": tenantId,
+                            "publicURL": "https://servers.api.rackspacecloud.com/v1.0/"+ tenantId,
+                            "version": {
+                                "versionInfo": "https://servers.api.rackspacecloud.com/v1.0/",
+                                "versionList": "https://servers.api.rackspacecloud.com/",
+                                "versionId": "1.0"
+                            }
+                        }
+                    ],
+                    "name": "cloudServers",
+                    "type": "compute"
+                },
+                {
+                    "endpoints": [
+                        {
+                            "region": "ORD",
+                            "tenantId": tenantId,
+                            "publicURL": "https://cdn2.clouddrive.com/v1/" + tenantId,
+                            "version": {
+                                "versionInfo": "https://cdn2.clouddrive.com/v1/",
+                                "versionList": "https://cdn2.clouddrive.com/",
+                                "versionId": "1"
+                            }
+                        }
+                    ],
+                    "name": "cloudFilesCDN",
+                    "type": "object-store"
+                }
+            ],
+            "user": {
+                "id": "149058",
+                "roles": [
+                    {
+                        "id": "identity:default",
+                        "description": "Default Role.",
+                        "name": "identity:default"
+                    }
+                ],
+                "name": username
+            }
+        }
+    };
+  }
+
+  body = JSON.stringify(body);
+  console.log('getToken_v2_0, statusCode=%s, body=%s', statusCode, body);
+  res.writeHead(statusCode, {'Content-Type': 'application/json'});
+  res.end(body);
+}
+
+
+function validateToken_v2_0(req, res) {
+  var type = req.query.type,
+      token = req.params.tokenId,
+      tenantId,
+      fail = req.query.fail ? true : false,
+      expiresTs = misc.getUnixTimestamp(),
+      username,
+      expires,
+      statusCode,
+      body,
+      creds,
+      ti,
+      reason = 'api was asked to fail';
+
+  expires = new Date();
+  expires.setTime((expiresTs + 100) * 1000);
+  expires = expires.toString();
+
+  if (!fail && !req.headers['x-auth-token']) {
+    fail = true;
+    statusCode = 500;
+    reason = 'missing X-Auth-Token header';
+  }
+  else if (!fail) {
+    ti = TOKEN_TO_INFO[token];
+
+    if (!ti) {
+      username = 'reachdevsf';
+      tenantId = '666';
+    }
+    else {
+      username = ti[0];
+      tenantId = ti[1];
+    }
+
+    if (!username || !tenantId) {
+      fail = true;
+      statusCode = 501;
+      reason = 'missing token in map auth map: ' + token + ' token:' + username + ' tenantId:' + tenantId;
+    }
+  }
+
+  if (fail) {
+    statusCode = statusCode || 401;
+    body = {unauthorized: {code: statusCode, message: reason}};
+  }
+  else if (tenantId !== req.query.belongsTo) {
+    statusCode = 404;
+    body = {"itemNotFound":{"code":404,"message":"Token doesn't belong to Tenant with Id/Name: '"+ req.query.belongsTo +"' realTenantId:"+ tenantId}};
+  }
+  else {
+    statusCode = 200;
+    body = {
+        "access": {
+            "token": {
+                "id": token,
+                "expires": expires
+            },
+            "user": {
+                "id": "149058",
+                "roles": [
+                    {
+                        "id": "identity:default",
+                        "description": "Default Role.",
+                        "name": "identity:default"
+                    }
+                ],
+                "name": username
+            }
+        }
+    };
+  }
+
+  body = JSON.stringify(body);
+  console.log('validateToken_v2_0, statusCode=%s, body=%s', statusCode, body);
+  res.writeHead(statusCode, {'Content-Type': 'application/json'});
+  res.end(body);
+}
+
+
+function getTenantInfo_v2_0(req, res) {
+  if (TENANT_ID_TO_USERNAME_MAP[req.params.tenantId]) {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify({
+      tenant: {
+        enabled: true,
+        description: 'None',
+        name: 'some tenant\'s name'
+      }
+    }));
+  } else {
+    res.writeHead(404, {});
+    res.end();
+  }
+}
+
+
+/**
+ * Run mock Auth 1.1 API http server.
+ */
+function run() {
+  var ip = '127.0.0.1',
+      port = 23542,
+      server = express.createServer();
+
+  server.use(express.bodyParser());
+  server.get('/v1.1/token/:tokenId', handleRequest_v_1_1);
+  server.post('/v2.0/tokens', getToken_v2_0);
+  server.get('/v2.0/tokens/:tokenId', validateToken_v2_0);
+  server.get('/v2.0/tenants/:tenantId', getTenantInfo_v2_0);
+  server.listen(port, ip);
+  util.puts(sprintf('Mock Auth HTTP server listening on IP %s port %s', ip, port));
+}
+
+
+exports.run = run;
+
+
+exports.USERNAME_TO_TOKEN_MAP = USERNAME_TO_TOKEN_MAP;
+exports.USERNAME_TO_TENANT_ID_MAP = USERNAME_TO_TENANT_ID_MAP;

--- a/node_modules/keystone-client/tests/test-keystone-client.js
+++ b/node_modules/keystone-client/tests/test-keystone-client.js
@@ -1,0 +1,89 @@
+var async = require('async');
+
+var request = require('rackspace-shared-utils/lib/request').request;
+var KeystoneClient = require('../lib/client').KeystoneClient;
+
+exports.test_validateTokenForTenant = function(test, assert) {
+  var client = new KeystoneClient('http://127.0.0.1:23542/v2.0');
+
+  async.waterfall([
+    function testInexistentTenantId(callback) {
+      client.validateTokenForTenant('inexistent', 'foo', function(err, data) {
+        assert.ok(err);
+        assert.equal(err.statusCode, 501);
+        assert.match(err.response.body.reason, /missing user in map auth map/);
+        callback();
+      });
+    },
+
+    function testInvalidToken(callback) {
+      client.validateTokenForTenant('7777', 'foo', function(err, data) {
+        assert.ok(err);
+        assert.equal(err.statusCode, 502);
+        assert.match(err.response.body.reason, /invalid token/);
+        callback();
+      });
+    },
+
+    function testValidToken(callback) {
+      client.validateTokenForTenant('7777', 'dev', function(err, data) {
+        assert.ifError(err);
+        assert.ok(data);
+        callback();
+      });
+    }
+  ],
+
+  function(err) {
+    test.finish();
+  });
+};
+
+exports.test_getTenantInfo = function(test, assert) {
+  var client = new KeystoneClient('http://127.0.0.1:23542/v2.0');
+
+  async.waterfall([
+    function testInexistentTenantId(callback) {
+      client.getTenantInfo('inexistent', {}, function(err, data) {
+        assert.ok(err);
+        assert.equal(err.statusCode, 404);
+        callback();
+      });
+    },
+
+    function testValidTenantId(callback) {
+      client.getTenantInfo('7777', {}, function(err, data) {
+        assert.ifError(err);
+        assert.ok(data);
+        callback();
+      });
+    }
+  ],
+
+  function(err) {
+    test.finish();
+  });
+};
+
+exports.test_getServiceCatalog = function(test, assert) {
+  var client = new KeystoneClient('http://127.0.0.1:23542/v2.0', {'username': 'joe', 'apiKey': 'dev'});
+
+  client.getServiceCatalog({}, function(err, data) {
+    assert.ifError(err);
+    assert.ok(data);
+    assert.ok(data.length > 1);
+    test.finish();
+  });
+};
+
+exports.test_getTenantIdAndToken = function(test, assert) {
+  var client = new KeystoneClient('http://127.0.0.1:23542/v2.0', {'username': 'joe', 'apiKey': 'dev'});
+
+  client.getTenantIdAndToken({}, function(err, data) {
+    assert.ifError(err);
+    assert.ok(data);
+    assert.equal(data.token, 'dev');
+    assert.equal(data.tenantId, '7777');
+    test.finish();
+  });
+};

--- a/package.json
+++ b/package.json
@@ -10,21 +10,22 @@
   "dependencies": {
     "async": "0.1.12",
     "connect": "1.7.x",
+    "emailjs": "0.1.19",
     "express": "2.5.6",
-    "logmagic": "0.1.4",
-    "sprintf": "0.1.1",
+    "graphite": "0.0.6",
+    "irc": "0.3.3",
     "jade": "0.20.0",
     "jshint": "0.7.1",
-    "optimist": "0.2.0",
-    "mkdirp": "0.2.1",
-    "request": "2.9.2",
-    "socket.io": "0.8.7",
-    "irc": "0.3.3",
-    "emailjs": "0.1.19",
+    "keystone-client": "0.3.0",
+    "logmagic": "0.1.4",
     "markdown": "0.3.1",
+    "mkdirp": "0.2.1",
     "node-hipchat": "0.1.0",
+    "optimist": "0.2.0",
+    "request": "2.9.2",
     "slack-notify": "0.1.1",
-    "graphite": "0.0.6"
+    "socket.io": "0.8.7",
+    "sprintf": "0.1.1"
   },
   "engines": {
     "node": ">=0.4.1 <0.7.0"


### PR DESCRIPTION
This adds support for Cloud Monitoring suppressions.

It provides a couple of basic functions:
- getEntities to list all entities on your account,
- getEntityIdsByRegexp to get all the entity ids whose label matches a specific regexp (useful when entity labels are set to server hostnames and you want to get i.e. all your api servers or all your servers in a region)
- createEntitiesSuppression to create a suppression on an array of entity ids,
- deleteSuppression to delete a suppression.
