### PR TITLE
Cleanup for sending to upstream racker repo

### DIFF
--- a/lib/util/jenkins.js
+++ b/lib/util/jenkins.js
@@ -21,8 +21,8 @@ var request = require('request');
 var logmagic = require('logmagic');
 var async = require('async');
 
-var TREE_FILTER = 'depth=1&tree=builds[actions[lastBuiltRevision[SHA1]],' +
-                  'result,building,timestamp,url,fullDisplayName,number]';
+var TREE_FILTER = 'depth=1&tree=builds[actions[lastBuiltRevision[SHA1],parameters[value,name]],'
+                + 'result,building,timestamp,url,fullDisplayName,number]';
 
 /**
  * Jenkins Client.
@@ -214,7 +214,11 @@ Jenkins.prototype.getRevision = function(builder, revision, callback) {
     for (i = 0; i < body.builds.length; i++) {
       build = body.builds[i];
       buildSha = self._getBuildSHA(build);
+      buildREV = self._getBuildREV(build);
       if (revision === buildSha) {
+        return callback(null, build);
+      }
+      if (revision === buildREV) {
         return callback(null, build);
       }
     }
@@ -239,6 +243,153 @@ Jenkins.prototype._getBuildSHA = function (build) {
       return action.lastBuiltRevision.SHA1;
     }
   }
+};
+
+/**
+  * Method to get the REV parameter that was passed, since
+  * this can be something other than a SHA1 revision hash,
+  * i.e. a tag or branch name.
+  **/
+Jenkins.prototype._getBuildREV = function (build) {
+  var actions = build.actions,
+      action, i;
+
+  for (i=0; i < build.actions.length; i++) {
+    action = actions[i];
+    if (action.hasOwnProperty('parameters')) {
+      for (var j=0; j < action.parameters.length; j++) {
+        var parameter = action.parameters[j];
+        if (parameter.hasOwnProperty('name')) {
+          if (parameter.name === "REV") {
+            return parameter.value;
+          }
+        }
+      }
+    }
+  }
+};
+
+Jenkins.prototype._getUpstreamNumber = function (build) {
+  var i, j, k;
+  if (build.hasOwnProperty('actions')) {
+    for (j = 0; j < build.actions.length; j++) {
+      var action = build.actions[j];
+      if (action.hasOwnProperty('causes')) {
+        for (k = 0; k < action.causes.length; k++) {
+          var cause = action.causes[k];
+          if (cause.hasOwnProperty('upstreamBuild')) {
+            return cause.upstreamBuild;
+          }
+        }
+      }
+    }
+  }
+};
+
+
+Jenkins.prototype.getBuildByUpstreamBuild = function(builder, build, callback) {
+  var qs = 'depth=1&tree=builds[actions[causes[upstreamBuild]],' +
+           'result,building,timestamp,url,fullDisplayName,number]';
+  // var qs = "depth=1&tree=builds[actions[causes[upstreamBuild]]]";
+  var url = util.format('%s/job/%s/api/json?%s', this._url, builder, qs),
+      self = this;
+
+  request.get(url, function(err, response, body) {
+    var i, j, buildSha;
+
+    console.log(build);
+    self.log.infof('Got builds from Jenkins, looking for build ${build_num}...', {
+      build_num: build.number
+    });
+
+    if (err) {
+      return callback(err);
+    }
+
+    try {
+      body = JSON.parse(body);
+    } catch (e) {
+      return callback(e);
+    }
+
+    for (i = 0; i < body.builds.length; i++) {
+      b = body.builds[i];
+      var upstream_build = self._getUpstreamNumber(b);
+      if (upstream_build === build.number) {
+        return callback(null, b);
+      }
+    }
+    callback();
+  });
+};
+
+/**
+ * Method to check the status of a downstream build.
+ *
+ * @param build {Object} Jenkins build
+ * @param dsProjectName {String} Name of the downstream project
+ * @return
+ */
+Jenkins.prototype.ensureDownstreamBuilt = function(upstream_build, dsProjectName, callback) {
+  var qs = "depth=1&tree=builds[actions[causes[upstreamBuild]]]";
+  var url = util.format('%s/job/%s/api/json?%s', this._url, dsProjectName, qs),
+      self = this;
+
+
+  var polling = false;
+  var attempts = 0;
+  var build = null;
+
+  function getLastBuild(callback) {
+    self.getBuildByUpstreamBuild(dsProjectName, upstream_build, function(err, last_build) {
+      if (err) {
+        return callback(err, null);
+      }
+
+      if (!build || build.building === false) {
+        attempts++;
+      }
+
+      build = last_build;
+      callback(null, build);
+    });
+  }
+
+  function pollJenkins(asyncCallback) {
+    var errorMsg;
+
+    if (!polling) {  // Wait a few seconds before the first poll
+      polling = true;
+      setTimeout(asyncCallback, self._options.delay);
+      return;
+    }
+
+    if (attempts > self._options.attempts) {
+      errorMsg = util.format('ERROR: Jenkins did not report a build after checking %s times',
+                             attempts);
+      return asyncCallback(new Error(errorMsg), null);
+    }
+
+    setTimeout(getLastBuild, self._options.delay, asyncCallback);
+  }
+
+  function isBuilt() {
+    if (self.isBuildComplete(build)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  getLastBuild(function(err, retrievedBuild) {
+    if (err) {
+      callback(err);
+    } else if (retrievedBuild && self.isBuildComplete(build)) {
+      callback(null, retrievedBuild);
+    } else {
+      async.until(isBuilt, pollJenkins, function(err) { callback(err, build); });
+    }
+  });
 };
 
 exports.Jenkins = Jenkins;

--- a/lib/util/knife.js
+++ b/lib/util/knife.js
@@ -26,7 +26,7 @@ var sprintf = require('./sprintf');
 function knife(args, options) {
   return function(callback) {
     var env = misc.copyEnv();
-    var knife_path = '/usr/bin/knife';
+    var knife_path = '/usr/local/bin/knife';
     options = options || {};
 
     // Support for these must be implemented in your knife.rb
@@ -115,6 +115,38 @@ function dataBagSet(bagName, obj, options, callback) {
 }
 
 
+function nodeGet(nodeName, options, callback) {
+  if (!callback) {
+    callback = options;
+    options = null;
+  }
+  knife(['node', 'show', '-l', '-F', 'json', nodeName], options)(callback);
+}
+
+
+function nodeFromFile(nodeName, fileName, options, callback) {
+  if (!callback) {
+    callback = options;
+    options = null;
+  }
+  knife(['node', 'from', 'file', fileName], options)(callback);
+}
+
+
+function nodeSet(nodeName, obj, options, callback) {
+  if (!callback) {
+    callback = options;
+    options = null;
+  }
+  var filename = sprintf('/tmp/node-%s.json', misc.randstr(8));
+  async.series([
+    fs.writeFile.bind(null, filename, JSON.stringify(obj)),
+    nodeFromFile.bind(null, nodeName, filename, options),
+    fs.unlink.bind(null, filename)
+  ], callback);
+}
+
+
 function knifeNodeList(options, callback) {
   if (!callback) {
     callback = options;
@@ -124,8 +156,8 @@ function knifeNodeList(options, callback) {
 }
 
 
-function queryAndRun(baton, args, query, cmd, msg, options, callback) {
-  if (!callback) {
+function queryAndRun(baton, args, query, cmd, msg, options, callback, output_parser) {
+  if (!output_parser && !callback) {
     callback = options;
     options = null;
   }
@@ -136,7 +168,7 @@ function queryAndRun(baton, args, query, cmd, msg, options, callback) {
 
   getHostParams = options && options.getHostParams ? options.getHostParams : function(hostObj) {
     return {
-      ip: hostObj.automatic.ipaddress
+      ip: hostObj.automatic.fqdn
     };
   };
 
@@ -161,17 +193,28 @@ function queryAndRun(baton, args, query, cmd, msg, options, callback) {
       return;
     }
 
-    function onComplete(err) {
+    function onComplete(err, stdout, stderr) {
       if (!err) {
         baton.log.infof(msg, misc.merge({name: name}, hostParams));
       }
 
       if (stopOnFailure) {
         callback(err);
-      } else {
-        // Do not short circuit on error
-        callback(null, err);
+        return;
       }
+
+      if (stderr) {
+        callback(null, new Error(stderr));
+        return;
+      }
+
+      if (output_parser) {
+        callback(null, output_parser(stdout, stderr));
+        return;
+      }
+
+      // Never short circuit on error
+      callback(null, err);
     }
 
     if (typeof cmd === 'function') {
@@ -256,7 +299,10 @@ exports.search = knifeSearch;
 
 /** Export Node */
 exports.node = {
- list: knifeNodeList
+ list: knifeNodeList,
+ set: nodeSet,
+ get: nodeGet,
+ setFromFile: nodeFromFile
 };
 
 

--- a/lib/util/newrelic.js
+++ b/lib/util/newrelic.js
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2012 Needle
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var url = require('url');
+var querystring = require('querystring');
+
+var logmagic = require('logmagic');
+var request = require('request');
+
+var misc = require('./misc');
+var sprintf = require('./sprintf');
+
+
+/**
+ * NewRelic Client.
+ * @constructor
+ * @param {Object} options The options.
+ */
+function NewRelic(license_key, options, log) {
+  this.url = "https://api.newrelic.com";
+  this._options = options;
+  this.license_key = license_key;
+
+  if (!this._options.hasOwnProperty('user')) {
+    this._options['user'] = 'dreadnot';
+  }
+
+  this.log = log || logmagic.local('sensu');
+}
+
+
+/**
+ * Notify NewRelic of a deploy
+ */
+NewRelic.prototype.send_deploy_message = function(stack, callback) {
+  var self = this,
+             reqOpts,
+             request_data;
+
+  request_data = "";
+
+  if (!this._options.hasOwnProperty('application_id')) {
+    callback(new Error('No application_id passed to NewRelic!'));
+    return;
+  }
+
+  for (var key in this._options) {
+    if (!request_data) {
+      request_data = sprintf("deployment[%s]=%s", key, this._options[key]);
+    } else {
+      request_data = sprintf("%s&deployment[%s]=%s", request_data, key, this._options[key]);
+    }
+  }
+
+  reqOpts = {
+    method: 'POST',
+    uri: sprintf('%s/deployments.xml', this.url),
+    headers: {
+      "x-license-key": this.license_key
+    },
+    body: request_data
+  };
+
+  request(reqOpts, function(err, response, body) {
+    var obj;
+
+    if (err) {
+      callback(err);
+    } else if ([204, 201, 200].indexOf(response.statusCode) === -1) {
+      callback(new Error(sprintf('Received %s from %s', response.statusCode, self.url)));
+    }
+    callback(err, body);
+  });
+};
+
+exports.NewRelic = NewRelic;

--- a/lib/util/sensu.js
+++ b/lib/util/sensu.js
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2012 Needle
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+var url = require('url');
+var querystring = require('querystring');
+
+var logmagic = require('logmagic');
+var request = require('request');
+
+var misc = require('./misc');
+var sprintf = require('./sprintf');
+
+
+/**
+ * Sensu Client.
+ * @constructor
+ * @param {Object} options The options.
+ */
+function Sensu(options, log) {
+  var parsed = url.parse(options.url);
+
+  this.url = options.url;
+  this.log = log || logmagic.local('sensu');
+}
+
+
+/**
+ * Silence a client's checks
+ */
+Sensu.prototype.silence = function(client_id, user, callback) {
+  var self = this,
+             reqOpts;
+
+  reqOpts = {
+    method: 'POST',
+    uri: sprintf('%s/stash/silence/%s', this.url, client_id),
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      timestamp: Math.round(new Date().getTime() / 1000),
+      actor: "dreadnot",
+      user: user
+    })
+  };
+
+  request(reqOpts, function(err, response, body) {
+    var obj;
+
+    if (err) {
+      callback(err);
+    } else if ([204, 201, 200].indexOf(response.statusCode) === -1) {
+      callback(new Error(sprintf('Received %s from %s', response.statusCode, self.url)));
+    }
+    callback(err, body);
+  });
+};
+
+
+/**
+ * Unsilence a client's checks
+ */
+Sensu.prototype.unsilence = function(client_id, user, callback) {
+  var self = this,
+             reqOpts;
+
+  reqOpts = {
+    method: 'DELETE',
+    uri: sprintf('%s/stash/silence/%s', this.url, client_id),
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  };
+
+  request(reqOpts, function(err, response, body) {
+    var obj;
+
+    if (err) {
+      callback(err);
+    } else if ([204, 201, 200].indexOf(response.statusCode) === -1) {
+      callback(new Error(sprintf('Received %s from %s', response.statusCode, self.url)));
+    }
+    callback(err, body);
+  });
+};
+
+
+exports.Sensu = Sensu;

--- a/lib/web/auth.js
+++ b/lib/web/auth.js
@@ -19,6 +19,7 @@ var crypto = require('crypto');
 var fs = require('fs');
 
 var AP_MD5PW_ID  = "$apr1$";
+var SHADOW_MD5PW_ID = "$1$";
 
 var ITOA64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
@@ -41,8 +42,10 @@ AuthDB.prototype.validate = function(username, password, callback) {
     callback(null, false);
   } else if (this.users[username].indexOf('{SHA}') === 0) {
     callback(null, this._validateSHA(password, this.users[username]));
-  } else if (this.users[username].indexOf('$apr1$') === 0) {
+  } else if (this.users[username].indexOf(AP_MD5PW_ID) === 0) {
     callback(null, this._validateMD5(password, this.users[username]));
+  } else if (this.users[username].indexOf(SHADOW_MD5PW_ID) === 0) {
+    callback(null, this._validateShadowMD5(password, this.users[username]));
   } else {
     callback(null, false);
   }
@@ -67,9 +70,13 @@ AuthDB.prototype._validateSHA = function(password, hash) {
 
 AuthDB.prototype._validateMD5 = function(password, hash) {
   var all = hash.split('$');
-  return md5crypt(password, all[2], '$apr1$') === hash;
+  return md5crypt(password, all[2], AP_MD5PW_ID) === hash;
 };
 
+AuthDB.prototype._validateShadowMD5 = function(password, hash) {
+  var all = hash.split('$');
+  return md5crypt(password, all[2], SHADOW_MD5PW_ID) === hash;
+};
 
 AuthDB.prototype.updateUsers = function(users) {
   this.users = users;


### PR DESCRIPTION
This is a rebased version of #44. There is a lot of good stuff in that PR and it went unmerged for a long time.

```
* Handling for shadow-style md5 passwords.
* Support to the knife plugin for editing node attributes
* Support to the jenkins plugin for handling downstream builds
* Adding a Sensu plugin for silencing/unsilencing nodes: https://github.com/sensu
* Adding a New Relic plugin for sending notifications about when deploys happen
```
Thanks to the people at Needle for all of this!