### PR TITLE
New Relic Deploy Plugin

### DIFF
--- a/lib/plugins/newrelic.js
+++ b/lib/plugins/newrelic.js
@@ -1,0 +1,56 @@
+var request = require('request');
+
+
+var log = require('logmagic').local('plugins.newrelic');
+
+exports.run = function(dreadnot) {
+  var config = dreadnot.config.plugins.newrelic;
+
+
+  log.info('loaded');
+
+  dreadnot.emitter.on('deployments', function(deployment) {
+    var endPath = [
+      'stacks',
+      deployment.stack,
+      'regions',
+      deployment.region,
+      'deployments',
+      deployment.deployment,
+      'end'
+    ].join('.');
+
+    dreadnot.emitter.once(endPath, function(success) {
+      if(success)
+      {
+        var app_ids = dreadnot.config.stacks[deployment.stack].newrelic_app_ids
+        if (typeof app_ids !== 'undefined' && app_ids)
+        {
+          app_ids.forEach(function(app_id)
+          {
+            var post_options = {
+              method: 'POST',
+              url: 'https://api.newrelic.com/deployments.xml',
+              headers : {
+                'x-api-key': config.api_key,
+                'Content-Type': 'application/x-www-form-urlencoded'
+              },
+              formData: {
+                'deployment[application_id]': app_id,
+                'deployment[revision]': deployment.to_revision,
+                'deployment[user]': deployment.user + ' ('+ (config.name) + ')'
+              }
+            };
+            request(post_options, function(error, response, body) {
+              log.info(JSON.stringify(body, null, 4));
+            });
+          });
+        }
+        else{
+          log.info('No New Relic App Id for ' + deployment.stack);
+        }
+      }
+    });
+  });
+};
+

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "0.2.1",
     "node-hipchat": "0.1.0",
     "optimist": "0.2.0",
-    "request": "2.9.2",
+    "request": "2.56",
     "slack-notify": "0.1.1",
     "socket.io": "0.8.7"
   },


### PR DESCRIPTION
Plugin to report successful deploys to new relic,

need to add below section to local_settings.js to enable 

```
plugins : {
      newrelic : {
        name: 'Dreadnot',
        api_key: 'newrelic api key'
      }
    }
```

and each stack will need a node like the following

```
    stacks: {
      server: {
        newrelic_app_ids: [8644158, 8413620]
      }
    }
```