### PR TITLE
Update Slack plugin to new API

### DIFF
--- a/lib/plugins/slack.js
+++ b/lib/plugins/slack.js
@@ -16,7 +16,7 @@
  *
  */
 
-var slack = require('node-slackr');
+var Slack = require('node-slackr');
 
 var helpers = require('web/view_helpers');
 var log = require('logmagic').local('plugins.slack');
@@ -24,87 +24,123 @@ var sprintf = require('util/sprintf');
 
 exports.run = function(dreadnot) {
   var config = dreadnot.config.plugins.slack,
-      MY_SLACK_WEBHOOK_URL = config.webhook_url,
-      client = new slack(MY_SLACK_WEBHOOK_URL);
+      slack = new Slack(config.webhook_url, {
+        channel: config.rooms,
+        username: config.name,
+        icon_url: config.icon,
+        icon_emoji: config.icon_emoji
+      });
 
-  log.info('loaded');
+  log.info('loaded slack notification plugin');
+
+
+  function logNotification(err, result) {
+    log.info('notifying slack channels', { channels: config.rooms });
+
+    if (err) {
+      log.error('slack error', { error: err, result: result });
+    }
+  }
+
 
   dreadnot.emitter.on('deployments', function(deployment) {
-    var link = sprintf(
-      '%s/stacks/%s/regions/%s/deployments/%s',
-      dreadnot.config.default_url,
-      deployment.stack,
-      deployment.region,
-      deployment.deployment
-    ),
-    msg = sprintf(
-      '%s is deploying %s to %s:%s - %s',
-      deployment.user,
-      deployment.stack,
-      dreadnot.config.env,
-      deployment.region,
-      link
-    ),
-    endPath = [
-      'stacks',
-      deployment.stack,
-      'regions',
-      deployment.region,
-      'deployments',
-      deployment.deployment,
-      'end'
-    ].join('.');
+    var link = sprintf('%s/stacks/%s/regions/%s/deployments/%s',
+                       dreadnot.config.default_url,
+                       deployment.stack,
+                       deployment.region,
+                       deployment.deployment),
 
-    var messages = {
-      text : '<' + link + '|Deploying>',
-      channel : config.rooms,
-      username : config.user,
-      icon_emoji : config.icon,
+        fallback = sprintf('%s is deploying %s to %s:%s - %s',
+                           deployment.user,
+                           deployment.stack,
+                           dreadnot.config.env,
+                           deployment.region,
+                           link),
+
+        pretext = sprintf('Deployment <%s|#%s> of %s to %s:%s by %s',
+                          link, deployment.deployment,
+                          deployment.stack, dreadnot.config.env,
+                          deployment.region, deployment.user),
+
+        from_to = sprintf('%s → %s',
+                          helpers.trimRevision(deployment.from_revision),
+                          helpers.trimRevision(deployment.to_revision)),
+
+        diff_url = helpers.ghDiffUrl(deployment.github_href,
+                                     deployment.from_revision,
+                                     deployment.to_revision),
+
+        endPath = ['stacks', deployment.stack,
+                   'regions', deployment.region,
+                   'deployments', deployment.deployment,
+                   'end'
+                  ].join('.');
+
+    var message = {
       attachments: [
-        { fallback: msg,
-          fields: [
-            { title: 'User', value: deployment.user, short: true },
-            { title: 'Stack', value: deployment.stack, short: true },
-            { title: 'Environment', value: dreadnot.config.env, short: true },
-            { title: 'Region', value: deployment.region, short: true }
-          ]
+        { fallback: fallback,
+          pretext: pretext,
+          title: from_to,
+          title_link: diff_url
         }
       ]
     };
 
-    client.notify(messages, function (err, result) {
-      console.log(err, result);
-    });
+    slack.notify(message, logNotification);
 
     dreadnot.emitter.once(endPath, function(success) {
-      var endMsg = sprintf(
-        'deployment #%s of %s to %s:%s %s',
-        deployment.deployment,
-        deployment.stack,
-        dreadnot.config.env,
-        deployment.region,
-        success ? 'SUCCEEDED' : 'FAILED'
-      );
+      var endMsg = sprintf('deployment #%s of %s to %s:%s %s',
+                           deployment.deployment,
+                           deployment.stack,
+                           dreadnot.config.env,
+                           deployment.region,
+                           success ? 'SUCCEEDED' : 'FAILED'),
 
-      client.notify({
-        channel: config.rooms,
-        icon_emoji: config.icon,
-        text: '<' + link + '|Deployment> - ' + (success ? 'SUCCEEDED' : 'FAILED'),
-        username: config.name,
-        attachments: [
-          { fallback: endMsg,
-            color: success ? '#89B54C' : '#CB452A',
-            fields: [
-              { title: 'Stack', value: deployment.stack, short: true },
-              { title: 'Environment', value: dreadnot.config.env, short: true },
-              { title: 'Region', value: deployment.region, short: true },
-              { title: 'Deployment', value: deployment.deployment, short: true },
-              { title: 'Version', value: '<' + helpers.ghCommitUrl(deployment.github_href, deployment.to_revision) + '|' + helpers.trimRevision(deployment.to_revision) + '>', short: true },
-              { title: 'Diff', value: '<' + helpers.ghDiffUrl(deployment.github_href, deployment.from_revision, deployment.to_revision) + '|from ' + helpers.trimRevision(deployment.from_revision) + '>', short: true }
-            ]
-          }
-        ]
-      });
+          message = {
+            attachments: [{
+              fallback: endMsg,
+              pretext: pretext,
+              title: success ? 'SUCCEEDED' : 'FAILED',
+              color: success ? 'good' : 'danger'
+            }]
+          };
+
+      slack.notify(message, logNotification);
     });
+  });
+
+
+  dreadnot.emitter.on('warning.set', function(warn) {
+    var fallback = sprintf('Warning has been set to "%s" by %s',
+                           warn.text, warn.username);
+
+    var message = {
+      attachments: [{
+        fallback: fallback,
+        pretext: 'Warning set:',
+        author_name: warn.username,
+        text: warn.text,
+        color: 'warning'
+      }]
+    };
+
+    slack.notify(message, logNotification);
+  });
+
+
+  dreadnot.emitter.on('warning.removed', function(warn) {
+    var fallback = sprintf('Warning "%s" has been removed by %s',
+                           warn.text, warn.username);
+
+    var message = {
+      attachments: [{
+        fallback: fallback,
+        pretext: 'Warning removed:',
+        author_name: warn.username,
+        text: warn.text,
+      }]
+    };
+
+    slack.notify(message, logNotification);
   });
 };

--- a/lib/plugins/slack.js
+++ b/lib/plugins/slack.js
@@ -16,7 +16,7 @@
  *
  */
 
-var slack = require('slack-notify');
+var slack = require('node-slackr');
 
 var helpers = require('web/view_helpers');
 var log = require('logmagic').local('plugins.slack');
@@ -24,8 +24,8 @@ var sprintf = require('util/sprintf');
 
 exports.run = function(dreadnot) {
   var config = dreadnot.config.plugins.slack,
-      MY_SLACK_WEBHOOK_URL = 'https://' + config.company + '.slack.com/services/hooks/incoming-webhook?token=' + config.token,
-      client = slack(MY_SLACK_WEBHOOK_URL);
+      MY_SLACK_WEBHOOK_URL = config.webhook_url,
+      client = new slack(MY_SLACK_WEBHOOK_URL);
 
   log.info('loaded');
 
@@ -55,23 +55,25 @@ exports.run = function(dreadnot) {
       'end'
     ].join('.');
 
-    config.rooms.forEach(function(room, ix) {
-      log.info('post to room', {room: room, message: msg});
-      client.send({channel: room,
-        icon_url: config.icon,
-        text: '<' + link + '|Deploying>',
-        username: config.name,
-        attachments: [
-          { fallback: msg,
-            fields: [
-              { title: 'User', value: deployment.user, short: true },
-              { title: 'Stack', value: deployment.stack, short: true },
-              { title: 'Environment', value: dreadnot.config.env, short: true },
-              { title: 'Region', value: deployment.region, short: true }
-            ]
-          }
-        ]
-      });
+    var messages = {
+      text : '<' + link + '|Deploying>',
+      channel : config.rooms,
+      username : config.user,
+      icon_emoji : config.icon,
+      attachments: [
+        { fallback: msg,
+          fields: [
+            { title: 'User', value: deployment.user, short: true },
+            { title: 'Stack', value: deployment.stack, short: true },
+            { title: 'Environment', value: dreadnot.config.env, short: true },
+            { title: 'Region', value: deployment.region, short: true }
+          ]
+        }
+      ]
+    };
+
+    client.notify(messages, function (err, result) {
+      console.log(err, result);
     });
 
     dreadnot.emitter.once(endPath, function(success) {
@@ -84,26 +86,24 @@ exports.run = function(dreadnot) {
         success ? 'SUCCEEDED' : 'FAILED'
       );
 
-      config.rooms.forEach(function(room, ix) {
-        log.info('post to room', {room: room, message: msg});
-        client.send({channel: room,
-          icon_url: config.icon,
-          text: '<' + link + '|Deployment> - ' + (success ? 'SUCCEEDED' : 'FAILED'),
-          username: config.name,
-          attachments: [
-            { fallback: endMsg,
-              color: success ? '#89B54C' : '#CB452A',
-              fields: [
-                { title: 'Stack', value: deployment.stack, short: true },
-                { title: 'Environment', value: dreadnot.config.env, short: true },
-                { title: 'Region', value: deployment.region, short: true },
-                { title: 'Deployment', value: deployment.deployment, short: true },
-                { title: 'Version', value: '<' + helpers.ghCommitUrl(deployment.github_href, deployment.to_revision) + '|' + helpers.trimRevision(deployment.to_revision) + '>', short: true },
-                { title: 'Diff', value: '<' + helpers.ghDiffUrl(deployment.github_href, deployment.from_revision, deployment.to_revision) + '|from ' + helpers.trimRevision(deployment.from_revision) + '>', short: true }
-              ]
-            }
-          ]
-        });
+      client.notify({
+        channel: config.rooms,
+        icon_emoji: config.icon,
+        text: '<' + link + '|Deployment> - ' + (success ? 'SUCCEEDED' : 'FAILED'),
+        username: config.name,
+        attachments: [
+          { fallback: endMsg,
+            color: success ? '#89B54C' : '#CB452A',
+            fields: [
+              { title: 'Stack', value: deployment.stack, short: true },
+              { title: 'Environment', value: dreadnot.config.env, short: true },
+              { title: 'Region', value: deployment.region, short: true },
+              { title: 'Deployment', value: deployment.deployment, short: true },
+              { title: 'Version', value: '<' + helpers.ghCommitUrl(deployment.github_href, deployment.to_revision) + '|' + helpers.trimRevision(deployment.to_revision) + '>', short: true },
+              { title: 'Diff', value: '<' + helpers.ghDiffUrl(deployment.github_href, deployment.from_revision, deployment.to_revision) + '|from ' + helpers.trimRevision(deployment.from_revision) + '>', short: true }
+            ]
+          }
+        ]
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-hipchat": "0.1.0",
     "optimist": "0.2.0",
     "request": "2.9.2",
-    "slack-notify": "0.1.1",
+    "node-slackr": "0.1.0",
     "socket.io": "0.8.7"
   },
   "analyze": true,


### PR DESCRIPTION
This builds on the work by @ebensing in #69 (thanks!). I dropped the vendored dependencies, updated the formatting, and added notifications for deploy warnings.

Deploys:
![dreadnot_deploy](https://cloud.githubusercontent.com/assets/240676/8466443/c927c400-2020-11e5-887d-838e6158575d.png)

Warnings:
![dreadnot_warnings](https://cloud.githubusercontent.com/assets/240676/8466448/d6855f9a-2020-11e5-9ec2-2b60cec4f745.png)
