### PR TITLE
feature(stack): Added a 'finally' target

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,13 @@ file that exports
   `environment` and `region` fields, and a callback taking `(err,
   deployed_revision)`.
 * A `targets` hash that maps target names to lists of task names. Currently,
-  the only supported target is `deploy` which defaults to
-  `['task_preDeploy', 'task_deploy', 'task_postDeploy']`.
+  the only supported targets are `deploy`, which defaults to
+  `['task_preDeploy', 'task_deploy', 'task_postDeploy']`, and `finally` which
+  does not have a default value. You should use the `finally` target if there are
+  any tasks you would like to run every time, regardless of the success or failure
+  of the tasks in `deploy` (i.e. re-enable monitoring alerts). The tasks in the `finally`
+  target itself are each dependent on the success of the last task in the target, so
+  an error in one will prevent the rest from running.
 * One or more "task functions" whose names are prefixed with `task_`. Each
   task function takes:
   1.  A "stack" object. The most useful fields on the stack are `stackConfig`

--- a/example/stacks/tapkick.js
+++ b/example/stacks/tapkick.js
@@ -31,8 +31,19 @@ exports.task_deploy = function(stack, baton, args, callback) {
   ], callback);
 };
 
+
+exports.task_cleanup = function(stack, baton, args, callback) {
+  baton.log.info('This gets logged whether the deploy succeeds or fails');
+  callback();
+};
+
+
 exports.targets = {
   'deploy': [
-    'task_deploy',
+    'task_deploy'
+  ],
+
+  'finally': [
+    'task_cleanup'
   ]
 };

--- a/lib/stack.js
+++ b/lib/stack.js
@@ -30,7 +30,8 @@ var sprintf = require('./util/sprintf');
 var errors = require('./errors');
 
 var DEFAULT_TARGETS = {
-  'deploy': ['task_predeploy', 'task_deploy', 'task_postdeploy']
+  'deploy': ['task_predeploy', 'task_deploy', 'task_postdeploy'],
+  'finally': null
 };
 
 
@@ -194,6 +195,7 @@ Stack.prototype.getTarget = function(name) {
 Stack.prototype.run = function(name, region, revision, user, finalCallback) {
   var self = this,
       target = self.getTarget(name),
+      finallyTarget = self.getTarget('finally'),
       baton = {},
       args = {
         dryrun: this.stackConfig.dryrun,
@@ -202,7 +204,7 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
         revision: revision,
         user: user
       },
-      lockNames, start, number, tasks;
+      lockNames, start, number, tasks, finallyTasks;
 
   if (this.newestDeployments[region] === undefined) {
     finalCallback(new errors.NotFoundError('Region not found'));
@@ -304,6 +306,39 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
         };
       });
 
+      if (finallyTarget) {
+        finallyTasks = finallyTarget.map(function(taskName) {
+          return function(callback) {
+            var startTime, endTime;
+
+            baton.log.infof('executing task ${task}', {
+              task: taskName
+            });
+
+            startTime = misc.getUnixTimestamp();
+            self.module[taskName](self, baton, args, function onEnd(err) {
+              var args = arguments, logObj;
+              endTime = misc.getUnixTimestamp();
+
+              logObj = {
+                task: taskName,
+                start_time: startTime,
+                end_time: endTime,
+                took: (endTime - startTime)
+              };
+
+              if (err) {
+                logObj.err = err;
+              }
+
+              baton.log.infof('task ${task} finished', logObj);
+
+              callback.apply(self, args);
+            });
+          };
+        });
+      }
+
       baton.log.infof('Starting deployment ${deployment} of target \'${target}\'', {
         deployment: number,
         target: name
@@ -312,26 +347,51 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
       async.series(tasks, function(err) {
         var seconds = (Date.now() - start) / 1000;
 
-        if (err) {
-          baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s', {
-            target: name,
-            seconds: seconds,
-            err: err.toString()
+        if (finallyTasks) {
+          if (err) {
+            baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s', {
+              target: name,
+              seconds: seconds,
+              err: err.toString()
+            });
+          }
+          async.series(finallyTasks, function(_err) {
+            if (_err) {
+              baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s while running "finally" block', {
+                target: name,
+                seconds: seconds,
+                err: _err.toString()
+              });
+            }
+            self.emit(['regions', region, 'deployments', number, 'end'].join('.'), self.current.success);
+
+            self.dreadnot.emitter.removeListener(epath, onLog);
+            self.current.finished = true;
+
+            callback();
           });
         } else {
-          self.current.success = true;
-          baton.log.infof('Target \'${target}\' SUCCESS in ${seconds}s', {
-            target: name,
-            seconds: seconds
-          });
+          if (err) {
+            baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s', {
+              target: name,
+              seconds: seconds,
+              err: err.toString()
+            });
+          } else {
+            self.current.success = true;
+            baton.log.infof('Target \'${target}\' SUCCESS in ${seconds}s', {
+              target: name,
+              seconds: seconds
+            });
+          }
+
+          self.emit(['regions', region, 'deployments', number, 'end'].join('.'), self.current.success);
+
+          self.dreadnot.emitter.removeListener(epath, onLog);
+          self.current.finished = true;
+
+          callback();
         }
-
-        self.emit(['regions', region, 'deployments', number, 'end'].join('.'), self.current.success);
-
-        self.dreadnot.emitter.removeListener(epath, onLog);
-        self.current.finished = true;
-
-        callback();
       });
 
       // Don't return to the user until the summary is generated and the


### PR DESCRIPTION
*What*
Let users add a target that will execute after the success or failure of the 'deploy' target

*How*
stack.js: Let user define a 'finally' target that will run after success or failure of the 'deploy' target
README.md: Updated readme to describe the 'finally' target

*Why*
Currently, if a deploy fails, it means that we won't clean up the suppressions we put in place at the start of the deploy. This lets us perform cleanup actions regardless of failure