### PR TITLE
fix(stack): log success in finally block

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -362,6 +362,12 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
                 seconds: seconds,
                 err: _err.toString()
               });
+            } else {
+              self.current.success = true;
+              baton.log.infof('Target \'${target}\' SUCCESS in ${seconds}s', {
+                target: name,
+                seconds: seconds
+              });
             }
             self.emit(['regions', region, 'deployments', number, 'end'].join('.'), self.current.success);
 


### PR DESCRIPTION
*What*
Actually say we succeeded if the finally block succeeds

*How*
stack.js: fixed finally block

*Why*
This is currently broken (see https://ele-dreadnot.cm.k1k.me/stacks/chef/regions/iad2/deployments/401)
