### PR TITLE
fix(stack): Fail deploy if deploy target fails, even if finally target succeeds

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -356,10 +356,18 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
             });
           }
           async.series(finallyTasks, function(_err) {
+            var finallySeconds = (Date.now() - start) / 1000;
+
             if (_err) {
-              baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s while running "finally" block', {
-                target: name,
+              baton.log.errorf('Target \'${target}\' FAILED in ${seconds}s', {
+                target: 'finally',
                 seconds: seconds,
+                err: _err.toString()
+              });
+            } else if (err) {
+              baton.log.errorf('Target \'finally\' SUCCESS in ${seconds}s, but target \'${target}\' FAILED', {
+                target: 'finally',
+                seconds: finallySeconds,
                 err: _err.toString()
               });
             } else {

--- a/lib/stack.js
+++ b/lib/stack.js
@@ -366,7 +366,7 @@ Stack.prototype.run = function(name, region, revision, user, finalCallback) {
               });
             } else if (err) {
               baton.log.errorf('Target \'finally\' SUCCESS in ${seconds}s, but target \'${target}\' FAILED', {
-                target: 'finally',
+                target: name,
                 seconds: finallySeconds,
                 err: _err.toString()
               });


### PR DESCRIPTION
*How*
stack.js: do not set success in the 'finally' block if an error occurred in the 'deploy' target

*Why*
Right now, if the deploy fails, but the 'finally' target succeeds, we'll call the deploy a success. This fixes that