### PR TITLE
feat(api/deploy): Default to redeploy if to_revision is not set

### DIFF
--- a/lib/web/handlers/api.js
+++ b/lib/web/handlers/api.js
@@ -77,9 +77,9 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
   // stack locked errors, redirect to the region view, otherwise a full error
   // view.
   function deploy(req, res) {
-        var stackName = req.params.stack,
-        regionName = req.params.region,
-        to;
+    var stackName = req.params.stack,
+    regionName = req.params.region,
+    to;
 
     function deploy() {
       async.waterfall([

--- a/lib/web/handlers/api.js
+++ b/lib/web/handlers/api.js
@@ -77,34 +77,30 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
   // stack locked errors, redirect to the region view, otherwise a full error
   // view.
   function deploy(req, res) {
-    var stackName = req.params.stack,
+        var stackName = req.params.stack,
         regionName = req.params.region,
-        to = req.body.to_revision, user;
+        to;
 
-    async.waterfall([
-      dreadnot.deploy.bind(dreadnot, stackName, regionName, to, req.remoteUser.name),
+    function deploy() {
+      async.waterfall([
+        dreadnot.deploy.bind(dreadnot, stackName, regionName, to, req.remoteUser.name),
 
-      function(number, callback) {
-        dreadnot.getDeploymentSummary(stackName, regionName, number, callback);
-      }
-    ], res.respond);
-  }
+        function(number, callback) {
+          dreadnot.getDeploymentSummary(stackName, regionName, number, callback);
+        }
+      ], res.respond);
+    }
 
-  function getWarning(req, res) {
-    res.respond(null, {message: dreadnot.warning});
-  }
-
-  // Store the warning message
-  function saveWarning(req, res) {
-    var text = req.body.action === 'save' ? req.body.warning_text : '';
-
-    dreadnot.setWarning(req.remoteUser, text, function(err) {
-      if (err) {
-        res.respond(err);
-      } else {
-        getWarning(req, res);
-      }
-    });
+    //Make the to_revision field optional
+    if (typeof req.body !== 'undefined' || typeof req.body.to_revision !== 'undefined') {
+      to = req.body.to_revision;
+      deploy();
+    } else {
+      dreadnot.getStackSummary(req.params.stack, function(err, data) {
+        to = data["latest_revision"];
+        deploy();
+      });
+    }
   }
 
   // Return bound handlers


### PR DESCRIPTION
Allow automatic deploys without specifying to revision by making it default to current revision of that stack thats been deployed.

I noticed that in staging there's a specific revision that's been deployed over and over again, this should make that process easier. 

Note: This PR does not make dreadnot auto-deploy to the latest git revision, only the git revision that's already been deployed and who's sha1 hash can be retrieved by running stack.getSummary. 