### PR TITLE
feat(git-get-revision): 

### DIFF
--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -15,13 +15,14 @@
  *
  */
 
+
 var fs = require('fs'),
+    github = require('octonode'),
     path = require('path'),
     async = require('async'),
     mkdirp = require('mkdirp'),
     misc = require('./misc'),
     sprintf = require('sprintf-js').sprintf;
-
 
 function git(args, callback) {
   args = ['git'].concat(args);
@@ -143,16 +144,16 @@ exports.commitMsg = function(repo, ref, callback) {
     callback(null, stdout.replace(/(^\w{7}\s|\n)/g, ''));
   });
 };
-      
+
 
 exports.clone = function(repo, url, callback) {
   async.series([
     // 0755 = 493
     mkdirp.bind(null, path.dirname(repo), 493),
     git.bind(null, ['clone', url, repo])
-  ],
-  function(err) {
-    callback(err);
+    ],
+    function(err) {
+      callback(err);
   });
 };
 
@@ -170,4 +171,41 @@ exports.getLatestRevision = function(url, ref, callback) {
 
 exports.trimRevision = function(rev) {
   return rev.slice(0, 7);
+};
+
+
+// Fetches the SHA of the latest commit, on master if a branch isn't specified.
+// Uses the github api via a sdk called octonode, will not work for non github repositories.
+exports.gitClientGetSha = function(owner, stackName, username, password, branch, callback) {
+  if (typeof branch === 'function') {
+    branch = null;
+    callback = branch;
+  }
+
+  var repoUrl, latest_sha,
+      gitClient = github.client({
+        username: username,
+        password: password
+      });
+
+  if (branch) {
+    repoUrl = path.join('repos', owner, stackName, 'git', 'refs', 'heads', branch);
+    gitClient.get(repoUrl, {}, function(err, status, data, headers) {
+      if (err) {
+        return callback(err);
+      }
+
+      latest_sha = data["latest_sha"]["object"]["sha"];
+      return callback(null, latest_sha);
+    });
+  } else {
+    repoUrl = path.join('repos', owner, stackName, 'commits');
+    gitClient.get(repoUrl, {}, function(err, status, data, headers) {
+      if (err) {
+        return callback(err);
+      }
+      latest_sha = data[0]["sha"];
+      return callback(null, latest_sha);
+    });
+  }
 };

--- a/lib/web/app.js
+++ b/lib/web/app.js
@@ -136,6 +136,9 @@ exports.registerAPI = function(dreadnot, authdb) {
   app.get('/1.0/stacks/:stack/regions/:region/deployments/:deployment', apiHandlers.getDeployment);
   app.get('/1.0/stacks/:stack/regions/:region/deployments/:deployment/log', apiHandlers.getDeploymentLog);
 
+  app.post('/1.0/stacks/:stack/revision', apiHandlers.getLatestRevision);
+  app.post('/1.0/stacks/:stack/branch/:branch/revision', apiHandlers.getLatestRevisionOnBranch);
+
   app.post('/1.0/stacks/:stack/regions/:region/deployments', apiHandlers.deploy);
 
   app.get('/1.0/warning', apiHandlers.getWarning);

--- a/lib/web/handlers/api.js
+++ b/lib/web/handlers/api.js
@@ -18,6 +18,7 @@
 var async = require('async');
 
 var misc = require('../../util/misc');
+var git = require('../../util/git');
 var errors = require('../../errors');
 
 
@@ -72,17 +73,39 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
     });
   }
 
+  function _getLatestRevision(req, callback) {
+    var owner = req.body.owner || 'racker', // Owner is overwritable to allow broader use cases but defaults to racker for convenience.
+        stackName = req.params.stack,
+        username = req.body.username,
+        password = req.body.password,
+        branch = req.params.branch || req.body.branch;
+
+    git.gitClientGetSha(owner, stackName, username, password, branch, callback);
+  }
+
+  function getLatestRevision(req, res) {
+    _getLatestRevision(req, function(err, data) {
+      res.respond(err || null, {latest_sha: data});
+    });
+  }
+
+  function getLatestRevisionOnBranch(req, res) {
+    _getLatestRevision(req, function(err, data) {
+      res.respond(err || null, {latest_sha: data});
+    });
+  }
+
   // Handle attempted deployments. Redirect to the deployment on success. On
   // stack locked errors, redirect to the region view, otherwise a full error
   // view.
   function deploy(req, res) {
     var stackName = req.params.stack,
-    regionName = req.params.region,
-    to;
+        regionName = req.params.region,
+        name = req.remoteUser.name;
 
-    function deploy() {
+    function _deploy(to_revision) {
       async.waterfall([
-        dreadnot.deploy.bind(dreadnot, stackName, regionName, to, req.remoteUser.name),
+        dreadnot.deploy.bind(dreadnot, stackName, regionName, to_revision, name),
 
         function(number, callback) {
           dreadnot.getDeploymentSummary(stackName, regionName, number, callback);
@@ -91,14 +114,30 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
     }
 
     //Make the to_revision field optional
-    if (typeof req.body !== 'undefined' || typeof req.body.to_revision !== 'undefined') {
-      to = req.body.to_revision;
-      deploy();
-    } else {
-      dreadnot.getStackSummary(req.params.stack, function(err, data) {
-        to = data["latest_revision"];
-        deploy();
-      });
+    if (typeof req.body !== 'undefined') {
+      if (req.body.to_revision) {
+        // Deploy to a specified revision
+        _deploy(req.body.to_revision);
+      } else if (req.body.username && req.body.password) {
+        // Deploy to the latest git commit on the repo or the specified branch
+        // username and password are git username and password with sufficient credentials
+        _getLatestRevision(req, function (err, sha) {
+          if (err) {
+            res.respond(err);
+          } else {
+            _deploy(sha);
+          }
+        });
+      } else {
+        // Redeploy last deployed revision
+        dreadnot.getStackSummary(req.params.stack, function (err, data) {
+          if (err) {
+            res.respond(err);
+          } else {
+            _deploy(data["latest_revision"]);
+          }
+        });
+      }
     }
   }
 
@@ -133,6 +172,9 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
     getDeployment: getDeployment,
 
     getDeploymentLog: getDeploymentLog,
+
+    getLatestRevision: getLatestRevision,
+    getLatestRevisionOnBranch: getLatestRevisionOnBranch,
 
     deploy: deploy,
 

--- a/package.json
+++ b/package.json
@@ -46,11 +46,12 @@
     "mocha": "^2.3.3",
     "node-hipchat": "0.1.0",
     "node-slackr": "0.1.0",
+    "octonode": "^0.7.4",
     "optimist": "0.2.0",
+    "rewire": "^2.3.4",
     "request": "2.9.2",
     "socket.io": "0.8.7",
     "sprintf-js": "^1.0.3",
-    "rewire": "^2.3.4",
     "slack-notify": "0.1.1"
   },
   "analyze": true,


### PR DESCRIPTION
Implement a couple methods to get latest commits sha via the github api
Add two api routes that can fetch the sha of the latest commit and fetch the sha of the latest commit on a given branch.
Implement auto-deploy featurette more completely. Now the deploy api route can be supplied a POST body. 
The body must have your github username or password, or one with access credentials to the repository/stack you want to deploy. This will trigger a deploy to the latest revision on master. 
You can also supply a branch to trigger a deploy to the latest version of that branch.
Or you can supply a git sha to trigger a deploy to said sha
```
{
  to_revision: <sha>,
  username: <ghUsername>,
  password: <ghPassword>,
  branch: <branchName>
}
```