### PR TITLE
test(utils): add tests for git and sprintf

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 var util = require('util');
 
-var sprintf = require('sprintf-js');
+var sprintf = require('sprintf-js').sprintf;
 
 
 function DreadnotError(msg) {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -15,7 +15,7 @@
  *
  */
 
-var sprintf = require('sprintf-js');
+var sprintf = require('sprintf-js').sprintf;
 
 
 exports.run = function(dreadnot) {

--- a/lib/plugins/email.js
+++ b/lib/plugins/email.js
@@ -20,7 +20,7 @@ var async = require('async'),
     log = require('logmagic').local('plugins.email'),
 
     helpers = require('web/view_helpers'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 var BEG_SUBJ_FMT = 'Deployment #%s of %s to %s:%s started';
 var BEG_TEXT_FMT = [

--- a/lib/plugins/hipchat.js
+++ b/lib/plugins/hipchat.js
@@ -18,7 +18,7 @@
 var Hipchat = require('node-hipchat'),
 
     log = require('logmagic').local('plugins.hipchat'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 exports.run = function(dreadnot) {
   var config = dreadnot.config.plugins.hipchat,

--- a/lib/plugins/irc.js
+++ b/lib/plugins/irc.js
@@ -19,7 +19,7 @@ var async = require('async'),
     irc = require('irc'),
     log = require('logmagic').local('plugins.irc'),
 
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 exports.run = function(dreadnot) {
   var clients = {},

--- a/lib/plugins/slack.js
+++ b/lib/plugins/slack.js
@@ -19,7 +19,7 @@
 var Slack = require('node-slackr'),
     helpers = require('web/view_helpers'),
     log = require('logmagic').local('plugins.slack'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 exports.run = function(dreadnot) {
   var config = dreadnot.config.plugins.slack,

--- a/lib/stack.js
+++ b/lib/stack.js
@@ -22,7 +22,7 @@ var events = require('events'),
     async = require('async'),
     logmagic = require('logmagic'),
     mkdirp = require('mkdirp'),
-    sprintf = require('sprintf-js'),
+    sprintf = require('sprintf-js').sprintf,
 
     misc = require('./util/misc'),
     git = require('./util/git'),

--- a/lib/util/buildbot.js
+++ b/lib/util/buildbot.js
@@ -19,7 +19,7 @@ var url = require('url'),
     querystring = require('querystring'),
     logmagic = require('logmagic'),
     request = require('request'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 /**

--- a/lib/util/git.js
+++ b/lib/util/git.js
@@ -20,7 +20,7 @@ var fs = require('fs'),
     async = require('async'),
     mkdirp = require('mkdirp'),
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 function git(args, callback) {

--- a/lib/util/graphite.js
+++ b/lib/util/graphite.js
@@ -18,7 +18,7 @@
 var graphite = require('graphite'),
     logmagic = require('logmagic'),
     request = require('request'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 /**

--- a/lib/util/knife.js
+++ b/lib/util/knife.js
@@ -18,7 +18,7 @@
 var fs = require('fs'),
     async = require('async'),
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 function knife(args, options) {
   return function(callback) {

--- a/lib/util/misc.js
+++ b/lib/util/misc.js
@@ -15,7 +15,7 @@
  *
  */
 
-var sprintf = require('sprintf-js'),
+var sprintf = require('sprintf-js').sprintf,
     log = require('logmagic').local('deploy.helpers.misc'),
     spawn = require('child_process').spawn;
 

--- a/lib/util/nagios.js
+++ b/lib/util/nagios.js
@@ -27,7 +27,7 @@ var url = require('url'),
     request = require('request'),
 
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 /**

--- a/lib/util/newrelic.js
+++ b/lib/util/newrelic.js
@@ -21,7 +21,7 @@ var url = require('url'),
     request = require('request'),
 
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 // Hopefully newrelic retained backwards compatibility since the code here was most likely written for v1 of their api
 

--- a/lib/util/pagerduty.js
+++ b/lib/util/pagerduty.js
@@ -21,7 +21,7 @@ var url = require('url'),
     request = require('request'),
 
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 /**

--- a/lib/util/sensu.js
+++ b/lib/util/sensu.js
@@ -19,7 +19,7 @@ var url = require('url'),
     logmagic = require('logmagic'),
     request = require('request'),
     misc = require('./misc'),
-    sprintf = require('sprintf-js');
+    sprintf = require('sprintf-js').sprintf;
 
 
 /**

--- a/lib/web/handlers/web.js
+++ b/lib/web/handlers/web.js
@@ -17,7 +17,7 @@
 
 var async = require('async');
 
-var sprintf = require('sprintf-js');
+var sprintf = require('sprintf-js').sprintf;
 var misc = require('../../util/misc');
 var errors = require('../../errors');
 

--- a/lib/web/view_helpers.js
+++ b/lib/web/view_helpers.js
@@ -16,7 +16,7 @@
  */
 
 var git = require('util/git');
-var sprintf = require('sprintf-js');
+var sprintf = require('sprintf-js').sprintf;
 
 var DIFF_LINK_FMT = '(<a href="%s">diff</a>)';
 var COMMIT_LINK_FMT = '<a href="%s">%s</a>';

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "dreadnot": "./bin/dreadnot"
   },
   "scripts": {
-    "test": "node_modules/.bin/tape test/*.js",
-    "lint": "node_modules/.bin/jshint lib/**/*.js --config jshint.json"
+    "lint": "node_modules/.bin/jshint lib/**/*.js --config jshint.json",
+    "test": "mocha"
   },
   "main": "lib/dreadnot.js",
   "repository": {
@@ -28,8 +28,10 @@
     "Justin Gallardo <justin.gallardo@gmail.com>",
     "Michael Burns <maburns@gmail.com>"
   ],
+  "version": "0.1.4",
   "dependencies": {
-    "async": "^1.0.0",
+    "async": "0.1.12",
+    "chai": "^3.4.0",
     "connect": "1.7.x",
     "emailjs": "0.1.19",
     "express": "2.5.6",
@@ -41,12 +43,15 @@
     "logmagic": "0.1.4",
     "markdown": "0.3.1",
     "mkdirp": "0.2.1",
+    "mocha": "^2.3.3",
     "node-hipchat": "0.1.0",
     "node-slackr": "0.1.0",
     "optimist": "0.2.0",
     "request": "2.9.2",
     "socket.io": "0.8.7",
-    "sprintf-js": "^1.0.3"
+    "sprintf-js": "^1.0.3",
+    "rewire": "^2.3.4",
+    "slack-notify": "0.1.1"
   },
   "analyze": true,
   "license": "Apache 2.0",

--- a/test/git.js
+++ b/test/git.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var expect = require('chai').expect,
+  rewire = require('rewire'),
+  git = rewire('../lib/util/git'),
+  miscSpawnCalls,
+  mkdirpCalls;
+
+git.__set__('misc', {
+  spawn: function () {
+    var args = Array.prototype.slice.call(arguments),
+      cb = args[args.length-1];
+
+    miscSpawnCalls.push({ args: args });
+    process.nextTick(function () {
+      cb();
+    });
+  }
+});
+
+git.__set__('mkdirp', function () {
+  var args = Array.prototype.slice.call(arguments),
+    cb = args[args.length-1];
+
+  mkdirpCalls.push({ args: args });
+  process.nextTick(function () {
+    cb();
+  });
+});
+
+git.__set__('path', {
+  exists: function () {
+    var cb = arguments[1];
+
+    process.nextTick(function () {
+      cb(null, true);
+    });
+  },
+  dirname: function () {
+    return '/var/lol/repo';
+  }
+});
+
+describe('util.git', function () {
+  beforeEach(function () {
+    miscSpawnCalls = [];
+    mkdirpCalls = [];
+  });
+
+  describe('.fetch', function () {
+    it('runs git fetch', function (done) {
+      git.fetch('test-repo', function (err) {
+        if (err) {
+          return done(err);
+        }
+        expect(miscSpawnCalls[0].args[0]).to.eql([
+          'git',
+          '--git-dir=test-repo/.git',
+          '--work-tree=test-repo',
+          'fetch'
+        ]);
+        done();
+      });
+    });
+  });
+
+  describe('.checkout', function () {
+    it('runs git checkout', function (done) {
+      git.checkout('additional', 'pylons', function (err) {
+        if (err) {
+          return done(err);
+        }
+        expect(miscSpawnCalls[0].args[0]).to.eql([
+          'git',
+          '--git-dir=additional/.git',
+          '--work-tree=additional',
+          'checkout',
+          'pylons'
+        ]);
+        done();
+      });
+    });
+  });
+
+  describe('.resetHard', function () {
+    it('runs git reset --hard', function (done) {
+      git.resetHard('angular', 'HEAD^', function (err) {
+        if (err) {
+          return done(err);
+        }
+        console.log(miscSpawnCalls[0].args[0])
+        expect(miscSpawnCalls[0].args[0]).to.eql([
+          'git',
+          '--git-dir=angular/.git',
+          '--work-tree=angular',
+          'reset',
+          '--hard',
+          'HEAD^'
+        ]);
+        done();
+      });
+    });
+  });
+
+  describe('.clone', function () {
+    it('makes the directory', function (done) {
+      git.clone('/var/lol/repo/foo.git', 'https://github/yolo/swag',
+        function (err) {
+          if (err) {
+            return done(err);
+          }
+          expect(mkdirpCalls[0].args.slice(0, 2)).to.eql([
+            '/var/lol/repo',
+            parseInt('0755', 8)
+          ]);
+          done();
+        }
+      );
+    });
+
+    it('runs git clone', function (done) {
+      git.clone('/var/lol/repo/foo.git', 'https://github/yolo/swag',
+        function (err) {
+          if (err) {
+            return done(err);
+          }
+          expect(miscSpawnCalls[0].args[0]).to.eql([
+            'git',
+            'clone',
+            'https://github/yolo/swag',
+            '/var/lol/repo/foo.git'
+          ]);
+          done();
+        }
+      );
+    });
+  });
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--reporter spec
+--ui bdd
+--slow 10


### PR DESCRIPTION
This is a fixed up rebase of #68 
I've removed the tests for sprintf from kens PR since #91 replaces sprintf with an upstream module which has its own tests. #91 also removes our current test/test.js file which is also a test for our hand-rolled sprintf. 
This uses mocha. 
Also fixes an issue found via these tests introduced in #91