### PR TITLE
Tidy sweep

### DIFF
--- a/example/local_settings.js
+++ b/example/local_settings.js
@@ -13,7 +13,7 @@ exports.config = {
       regions: ['all']
     },
   },
-  tapkick_dir: '/data/tapkick',
+  tapkick_dir: 'data/tapkick',
   github: {
     organization: 'philips'
   },

--- a/example/stacks/tapkick.js
+++ b/example/stacks/tapkick.js
@@ -11,8 +11,16 @@ var git = require('util/git');
 
 exports.get_deployedRevision = function(args, callback) {
   git.revParse(this.config.tapkick_dir, 'HEAD', function(err, stdout) {
+    if (err) { return callback(err); }
     // trim leading and trailing whitespace
-    callback(null, stdout.replace(/^\s+|\s+$/g, ''));
+    var rev;
+    try {
+      rev =  stdout.replace(/^\s+|\s+$/g, '');
+    }
+    catch (error) {
+      return callback(error);
+    }
+    callback(null, rev);
   });
 };
 

--- a/lib/util/misc.js
+++ b/lib/util/misc.js
@@ -60,7 +60,7 @@ exports.spawn = function(cmd, spawnOpts, callback) {
   cmdStr = sprintf('%s %s', cmd[0], args.join(' '));
   log.info('Executing Command', {'cmd': cmdStr});
 
-  proc = spawn(cmd[0], args, spawnOpts);
+  proc = spawn(cmd[0], args, spawnOpts || {});
   proc.stdout.on('data', function(data) {
     resultString += data;
   });


### PR DESCRIPTION
This adds support for node 5.x (in a very safe way that doesn't break 0.10.x) and makes the tapkick sample more robust.