### PR TITLE
Fix deploy to last revision on dreadnot

### DIFF
--- a/lib/dreadnot.js
+++ b/lib/dreadnot.js
@@ -243,5 +243,13 @@ Dreadnot.prototype.getDeploymentLog = function(stackName, regionName, deployment
   }
 };
 
+Dreadnot.prototype.getDeployedRevision = function(stackName, regionName, callback) {
+  var stack = this._stacks[stackName];
+  if (!stack) {
+    callback(new errors.NotFoundError('Stack not found'));
+  } else {
+    stack.getDeployedRevision(regionName, callback);
+  }
+};
 
 exports.Dreadnot = Dreadnot;

--- a/lib/web/handlers/api.js
+++ b/lib/web/handlers/api.js
@@ -131,11 +131,11 @@ exports.getAPIHandlers = function(dreadnot, authdb) {
         });
       } else {
         // Redeploy last deployed revision
-        dreadnot.getStackSummary(req.params.stack, function (err, data) {
+        dreadnot.getDeployedRevision(req.params.stack, req.params.region, function(err, data) {
           if (err) {
             res.respond(err);
           } else {
-            _deploy(data["latest_revision"]);
+            _deploy(data["deployed_revision"]);
           }
         });
       }


### PR DESCRIPTION
Before this functionality was deploying to the tip of the git branch. Fixed to deploy to the last deployed revision. 