### PR TITLE
prefer the 'repo' value over the stack name, if available

### DIFF
--- a/lib/stack.js
+++ b/lib/stack.js
@@ -66,6 +66,7 @@ function Stack(name, dreadnot, config) {
   this.log = logmagic.local(logName);
   this.logRoot = path.join(config.data_root, 'logs', name);
   this.newestDeployments = {};
+  this.repo = this.stackConfig.repo || name;
   this.current = null;
   this._cache = {};
   this._waiting = {};
@@ -156,13 +157,13 @@ Stack.prototype._getCached = function(name, ttl, getter, callback) {
 
 Stack.prototype.getRepoUrl = function() {
   return this.stackConfig.git_url ||
-      sprintf('git@github.com:%s/%s.git', this.config.github.organization, this.name);
+      sprintf('git@github.com:%s/%s.git', this.config.github.organization, this.repo);
 };
 
 
 Stack.prototype.getGitHubBaseUrl = function() {
   return this.stackConfig.github_base_url ||
-      sprintf('https://github.com/%s/%s', this.config.github.organization, this.name);
+      sprintf('https://github.com/%s/%s', this.config.github.organization, this.repo);
 };
 
 


### PR DESCRIPTION
Fixes #119 

I want to add an (optional) config value to a Dreadnot stack that we define like this:

```
    FOO: {
      tip: 'master',
      tip_ttl: 120 * 1000,
      regions: ['bar', 'baz'],
      dryrun: false,
      named_locks: ['global']
    },
```

That value, `repo` will be used (if available) in place of `this.name` when constructing github.com URLs in the form: `github.com/racker/FOO.git`, where `FOO` is the name of the current stack (`stacks/FOO.js`).

* https://github.com/racker/dreadnot/blob/master/lib/stack.js#L157-L160
* https://github.com/racker/dreadnot/blob/master/lib/stack.js#L163-L166