### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "octonode": "^0.7.4",
     "optimist": "0.2.0",
     "rewire": "^2.3.4",
-    "request": "2.9.2",
+    "request": "2.74.0",
     "socket.io": "0.8.7",
     "slack-notify": "0.1.1",
     "underscore": "^1.8.3"


### PR DESCRIPTION
dreadnot currently has a 14 vulnerable dependency paths, introducing 11 different types of known vulnerabilities.

his PR fixes vulnerable dependencies, introducing [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/racker/dreadnot) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team