### PR TITLE
return node.name instead of automatic.ipaddress

### DIFF
--- a/lib/util/knife.js
+++ b/lib/util/knife.js
@@ -143,7 +143,7 @@ function queryAndRun(baton, args, query, cmd, msg, options, callback) {
 
   getHostParams = options && options.getHostParams ? options.getHostParams : function(hostObj) {
     return {
-      ip: hostObj.automatic.ipaddress
+      ip: hostObj.name
     };
   };
 


### PR DESCRIPTION
# What

Dreadnot returns the default ip address for a node from its search results.

This PR is an attempt to change that to be the node.name instead.

# Why

Dreadnot is returning IP addresses, but we should be looking up their address by DNS resolution (from `node.name` or `node.fqdn`, etc).